### PR TITLE
fix: pass arguments separately to spawn

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,8 @@ function buildArgs(root, targetFile, gradleArgs) {
     if (!fs.existsSync(path.resolve(root, targetFile))) {
       throw new Error('File not found: ' + targetFile);
     }
-    args.push('--build-file ' + targetFile);
+    args.push('--build-file');
+    args.push(targetFile);
   }
   if (gradleArgs) {
     args.push(gradleArgs);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

We've had bug reports that indicate that in certain circumstances
"--build-file build.gradle" is being treated by gradle/gradlew as a
single argument (including the space).

I've been unable to replicate the problem, but this change should
ensure that "--build-file" and the target-file path are always treated
as distinct arguments (rather than relying on a space!)
