### PR TITLE
feat: supporting args as an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,10 @@ module.exports = {
   inspect: inspect,
 };
 
+module.exports.__tests = {
+  buildArgs: buildArgs,
+};
+
 function inspect(root, targetFile, options) {
   if (!options) { options = { dev: false }; }
   return getPackage(root, targetFile, options)
@@ -94,7 +98,7 @@ function buildArgs(root, targetFile, gradleArgs) {
     args.push(targetFile);
   }
   if (gradleArgs) {
-    args.push(gradleArgs);
+    args = args.concat(gradleArgs);
   }
   return args;
 }

--- a/test/functional/gradle-plugin.test.js
+++ b/test/functional/gradle-plugin.test.js
@@ -1,0 +1,31 @@
+var test = require('tap-only');
+var plugin = require('../../lib').__tests;
+
+test('check build args with array', function (t) {
+  var result = plugin.buildArgs(null, null, [
+    '--build-file',
+    'build.gradle',
+    '--configuration',
+    'compile',
+  ]);
+  t.deepEqual(result, [
+    'dependencies',
+    '-q',
+    '--build-file',
+    'build.gradle',
+    '--configuration',
+    'compile',
+  ]);
+  t.end();
+});
+
+test('check build args with string', function (t) {
+  var result = plugin.buildArgs(null, null,
+    '--build-file build.gradle --configuration compile');
+  t.deepEqual(result, [
+    'dependencies',
+    '-q',
+    '--build-file build.gradle --configuration compile',
+  ]);
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Double-dash arguments are now sent as an array of strings, split by spaces.
Supports older, string-string arguments as well, so no breaking change here.