### PR TITLE
fix: throw proper error on failing gradle execution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,9 @@ function inspect(root, targetFile, options) {
   if (!options) {
     options = {dev: false};
   }
-  return getPackage(root, targetFile, options)
+  var command =  getCommand(root, targetFile);
+  var args = buildArgs(root, targetFile, options.args);
+  return getPackage(root, command, args)
     .then(function (pkg) {
     // opt-in with `jars` or `localjars` flag
       if (options.jars || options.localjars) {
@@ -40,14 +42,19 @@ function inspect(root, targetFile, options) {
         },
         package: pkg,
       };
+    })
+    .catch(function (error) {
+      error.message = error.message + '\n\n' +
+        'Please make sure that `' + command + ' ' + args.join(' ') +
+        '` executes successfully on this project.\n\n' +
+        'If the problem persists, collect the output of `' +
+        command + ' ' + args.join(' ') + '` and contact support@snyk.io\n';
+      throw error;
     });
 }
 
-function getPackage(root, targetFile, options) {
-  return subProcess.execute(
-    getCommand(root, targetFile),
-    buildArgs(root, targetFile, options.args),
-    {cwd: root})
+function getPackage(root, command, args) {
+  return subProcess.execute(command, args, {cwd: root})
     .then(function (result) {
       var packageName = path.basename(root);
       var packageVersion = '0.0.0';

--- a/lib/sub-process.js
+++ b/lib/sub-process.js
@@ -20,7 +20,7 @@ module.exports.execute = function (command, args, options) {
 
     proc.on('close', function (code) {
       if (code !== 0) {
-        return reject(stdout || stderr);
+        return reject(new Error(stdout || stderr));
       }
       resolve(stdout || stderr);
     });

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -31,6 +31,20 @@ test('run inspect()', function (t) {
     .catch(t.fail);
 });
 
+test('failing inspect()', function (t) {
+  t.plan(1);
+  stubSubProcessExec(t);
+  return plugin.inspect('.', path.join(
+    __dirname, '..', 'fixtures', 'no-wrapper', 'build.gradle'))
+    .then(function (result) {
+      t.fail('Should have thrown!', result);
+    })
+    .catch(function (error) {
+      t.match(error.message, 'executes successfully on this project',
+        'proper error message');
+    });
+});
+
 test('windows without wrapper', function (t) {
   t.plan(1);
 
@@ -134,7 +148,7 @@ function stubPlatform(platform, t) {
 function stubSubProcessExec(t) {
   sinon.stub(subProcess, 'execute')
     .callsFake(function () {
-      return Promise.reject('abort');
+      return Promise.reject(new Error('abort'));
     });
   t.teardown(subProcess.execute.restore);
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When `gradle` execution ends with an error, the plugin used to reject with a string containing the stdout or stderr of the `gradle` process. This doesn't work well with the CLI, which expects proper `Error` objects on plugin failure. Now fixed!