### PR TITLE
fix: handle (n) markers in `gradle dependencies` output

### DIFF
--- a/lib/gradle-dep-parser.js
+++ b/lib/gradle-dep-parser.js
@@ -61,6 +61,9 @@ function processGradleOutput(text) {
         omittedDeps[parts[0].trim() + ':' + parts[1]] = true;
       }
 
+      // trim (n) - Not resolved (configuration is not meant to be resolved)
+      element = element.split(' (n)')[0];
+
       return element;
     });
   return {

--- a/test/fixtures/api-configuration/build.gradle
+++ b/test/fixtures/api-configuration/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java-library'
+
+dependencies {
+  api 'commons-httpclient:commons-httpclient:3.1'
+}

--- a/test/fixtures/api-configuration/gradle-dependencies-output.txt
+++ b/test/fixtures/api-configuration/gradle-dependencies-output.txt
@@ -1,0 +1,70 @@
+------------------------------------------------------------
+Root project
+------------------------------------------------------------
+
+annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+No dependencies
+
+api - API dependencies for source set 'main'. (n)
+\--- commons-httpclient:commons-httpclient:3.1 (n)
+
+apiElements - API elements for main. (n)
+No dependencies
+
+archives - Configuration for archive artifacts.
+No dependencies
+
+compile - Dependencies for source set 'main' (deprecated, use 'implementation' instead).
+No dependencies
+
+compileClasspath - Compile classpath for source set 'main'.
+\--- commons-httpclient:commons-httpclient:3.1 FAILED
+
+compileOnly - Compile only dependencies for source set 'main'.
+No dependencies
+
+default - Configuration for default artifacts.
+\--- commons-httpclient:commons-httpclient:3.1 FAILED
+
+implementation - Implementation only dependencies for source set 'main'. (n)
+No dependencies
+
+runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
+No dependencies
+
+runtimeClasspath - Runtime classpath of source set 'main'.
+\--- commons-httpclient:commons-httpclient:3.1 FAILED
+
+runtimeElements - Elements of runtime for main. (n)
+No dependencies
+
+runtimeOnly - Runtime only dependencies for source set 'main'. (n)
+No dependencies
+
+testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
+No dependencies
+
+testCompile - Dependencies for source set 'test' (deprecated, use 'testImplementation' instead).
+No dependencies
+
+testCompileClasspath - Compile classpath for source set 'test'.
+\--- commons-httpclient:commons-httpclient:3.1 FAILED
+
+testCompileOnly - Compile only dependencies for source set 'test'.
+No dependencies
+
+testImplementation - Implementation only dependencies for source set 'test'. (n)
+No dependencies
+
+testRuntime - Runtime dependencies for source set 'test' (deprecated, use 'testRuntimeOnly' instead).
+No dependencies
+
+testRuntimeClasspath - Runtime classpath of source set 'test'.
+\--- commons-httpclient:commons-httpclient:3.1 FAILED
+
+testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
+No dependencies
+
+(n) - Not resolved (configuration is not meant to be resolved)
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/test/fixtures/api-configuration/gradle-dependencies-results.json
+++ b/test/fixtures/api-configuration/gradle-dependencies-results.json
@@ -1,0 +1,7 @@
+{
+  "commons-httpclient:commons-httpclient": {
+    "version": "3.1",
+    "name": "commons-httpclient:commons-httpclient",
+    "dependencies": {}
+  }
+}

--- a/test/functional/gradle-dep-parser.test.js
+++ b/test/functional/gradle-dep-parser.test.js
@@ -2,15 +2,15 @@ var fs = require('fs');
 var path = require('path');
 var test = require('tap-only');
 var parse = require('../../lib/gradle-dep-parser').parse;
-var fixturePath = path.join(__dirname, '..', 'fixtures', 'no-wrapper');
+var fixturePath = path.join(__dirname, '..', 'fixtures');
 
 test('compare full results', function (t) {
   t.plan(1);
   var gradleOutput = fs.readFileSync(
-    path.join(fixturePath, 'gradle-dependencies-output.txt'), 'utf8');
+    path.join(fixturePath, 'no-wrapper', 'gradle-dependencies-output.txt'), 'utf8');
   var depTree = parse(gradleOutput, 'myPackage@1.0.0');
   var results = require(
-    path.join(fixturePath,'gradle-dependencies-results.json'));
+    path.join(fixturePath, 'no-wrapper','gradle-dependencies-results.json'));
 
   t.same(depTree, results);
 });
@@ -18,7 +18,7 @@ test('compare full results', function (t) {
 test('parse a `gradle dependencies` output', function (t) {
   t.plan(7);
   var gradleOutput = fs.readFileSync(path.join(
-    fixturePath, 'gradle-dependencies-output.txt'), 'utf8');
+    fixturePath, 'no-wrapper', 'gradle-dependencies-output.txt'), 'utf8');
   var depTree = parse(gradleOutput, 'myPackage@1.0.0');
 
   t.equal(
@@ -68,4 +68,17 @@ test('parse a `gradle dependencies` output', function (t) {
       .dependencies['com.android.tools:common']
       .dependencies['com.google.guava:guava'].name,
     'com.google.guava:guava', 'resolved ommitted dependency name (2)');
+});
+
+test('parse a `gradle dependencies` output', function (t) {
+  return t.test('handle (n) marker', function (t) {
+    t.plan(1);
+    var gradleOutput = fs.readFileSync(path.join(
+      fixturePath, 'api-configuration', 'gradle-dependencies-output.txt'), 'utf8');
+    var depTree = parse(gradleOutput);
+    var results = require(
+      path.join(fixturePath, 'api-configuration','gradle-dependencies-results.json'));
+
+    t.same(depTree, results);
+  });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- strips `(n)` markers when parsing `gradle dependencies` output
