### PR TITLE
fix: drop top-level from path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,14 +58,12 @@ function getPackage(root, command, args) {
     .then(function (result) {
       var packageName = path.basename(root);
       var packageVersion = '0.0.0';
-      var from = packageName + '@' + packageVersion;
-      var depTree = depParser.parse(result, from);
+      var depTree = depParser.parse(result);
       return {
         dependencies: depTree,
         name: packageName,
         version: packageVersion,
         packageFormatVersion: packageFormatVersion,
-        from: [from],
       };
     });
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- drops the top-level `from` attribute from the response (so that we know to annotate it later)
