### PR TITLE
feat: option to specify sub-project in multi-project build

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,9 @@ function inspect(root, targetFile, options) {
     options = {dev: false};
   }
   var command =  getCommand(root, targetFile);
-  var args = buildArgs(root, targetFile, options.args);
-  return getPackage(root, command, args)
+  var subProject = options['gradle-sub-project'];
+  var args = buildArgs(root, targetFile, options.args, subProject);
+  return getPackage(root, command, args, subProject)
     .then(function (pkg) {
     // opt-in with `jars` or `localjars` flag
       if (options.jars || options.localjars) {
@@ -53,10 +54,13 @@ function inspect(root, targetFile, options) {
     });
 }
 
-function getPackage(root, command, args) {
+function getPackage(root, command, args, subProject) {
   return subProcess.execute(command, args, {cwd: root})
     .then(function (result) {
       var packageName = path.basename(root);
+      if (subProject) {
+        packageName += '/' + subProject;
+      }
       var packageVersion = '0.0.0';
       var depTree = depParser.parse(result);
       return {
@@ -97,8 +101,14 @@ function getCommand(root, targetFile) {
   return 'gradle';
 }
 
-function buildArgs(root, targetFile, gradleArgs) {
-  var args = ['dependencies', '-q'];
+function buildArgs(root, targetFile, gradleArgs, subProject) {
+  var args = [];
+  if (subProject) {
+    args.push(subProject + ':dependencies');
+  } else {
+    args.push('dependencies');
+  }
+  args.push('-q');
   if (targetFile) {
     if (!fs.existsSync(path.resolve(root, targetFile))) {
       throw new Error('File not found: ' + targetFile);

--- a/test/fixtures/multi-project/settings.gradle
+++ b/test/fixtures/multi-project/settings.gradle
@@ -1,0 +1,5 @@
+rootProject.name = 'root-proj'
+
+include 'subproj'
+
+

--- a/test/fixtures/multi-project/subproj/build.gradle
+++ b/test/fixtures/multi-project/subproj/build.gradle
@@ -1,0 +1,49 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'com.google.guava:guava:18.0'
+  compile 'batik:batik-dom:1.6'
+  compile 'commons-discovery:commons-discovery:0.2'
+  compile 'axis:axis:1.3'
+  compile 'com.android.tools.build:builder:2.3.0'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+// To specify a license in the pom:
+install {
+  repositories.mavenInstaller {
+    pom.project {
+      licenses {
+        license {
+          name 'The Apache Software License, Version 2.0'
+          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          distribution 'repo'
+        }
+      }
+    }
+  }
+}

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -137,6 +137,30 @@ test('darwin with wrapper in root', function (t) {
     });
 });
 
+test('only sub-project has deps', function (t) {
+  t.plan(2);
+  const options = {
+    'gradle-sub-project': 'subproj',
+  };
+  return plugin.inspect('.',
+    path.join(__dirname, '..', 'fixtures', 'multi-project', 'build.gradle'),
+    options)
+    .then(function (result) {
+      t.match(result.package.name, '/subproj',
+        'sub project name is included in the root pkg name');
+
+      t.equal(result.package
+        .dependencies['com.android.tools.build:builder']
+        .dependencies['com.android.tools:sdklib']
+        .dependencies['com.android.tools:repository']
+        .dependencies['com.android.tools:common']
+        .dependencies['com.android.tools:annotations'].version,
+      '25.3.0',
+      'correct version found');
+    })
+    .catch(t.fail);
+});
+
 function stubPlatform(platform, t) {
   sinon.stub(os, 'platform')
     .callsFake(function () {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

to support "multi-project" gradle projects: https://docs.gradle.org/current/userguide/multi_project_builds.html, a new `options['gradle-sub-project']` option allows the caller to specify the desired sub-project to scan.

#### How should this be manually tested?
can `npm link` with the `github.com/snyk/snyk` CLI, go to the `./test/fixtures/multi-proj` folder and run:
```bash
snyk test
snyk test --gradle-sub-project=subproj
```

#### Additional questions
do we like the naming of this option?
