### PR TITLE
Different scan results between different OS

### DIFF
--- a/lib/gradle-dep-parser.js
+++ b/lib/gradle-dep-parser.js
@@ -19,7 +19,7 @@ function processGradleOutput(text) {
     // filter out stuff that isn't dependencies
       return element.indexOf('\\---') !== -1 ||
       element.indexOf('+---') !== -1 ||
-      element === '';
+      element.match(/^\\s?(\\r\\n|\\r|\\n)/);
     })
     .reduce(function (acc, element) {
     // only return the first configuration, in case there are multiple


### PR DESCRIPTION
Hi, I was struggling to find a valid reason why the same project was analyzed differently between two OS with the same Snyk version:

**First OS**:
```
OS: Windows 7
Node version: 6.9.1
Npm version: 3.10.8
Snyk version: 1.104.1
Gradle version (using gradlew wrapper inside the project):
	------------------------------------------------------------
	Gradle 4.6
	------------------------------------------------------------

	Build time:   2018-02-28 13:36:36 UTC
	Revision:     8fa6ce7945b640e6168488e4417f9bb96e4ab46c

	Groovy:       2.4.12
	Ant:          Apache Ant(TM) version 1.9.9 compiled on February 2 2017
	JVM:          1.8.0_181-1-redhat (Oracle Corporation 25.181-b13)
	OS:           Windows 7 6.1 amd64

Command line: snyk test --file=app/build.gradle
Result: Tested 124 dependencies for known vulnerabilities, found 7 vulnerabilities, 207 vulnerable paths.
```

**Second OS**:
```
OS: Alpine 3.8.1 (Docker container)
Node version: 8.11.4
Npm version: 5.6.0
Snyk version: 1.104.1
Gradle version (using gradlew wrapper inside the project):
	------------------------------------------------------------
	Gradle 4.6
	------------------------------------------------------------

	Build time:   2018-02-28 13:36:36 UTC
	Revision:     8fa6ce7945b640e6168488e4417f9bb96e4ab46c

	Groovy:       2.4.12
	Ant:          Apache Ant(TM) version 1.9.9 compiled on February 2 2017
	JVM:          1.8.0_171 (Oracle Corporation 25.171-b11)
	OS:           Linux 4.12.14-lp150.12.22-default amd64
	
Command line: snyk test --file=app/build.gradle
Result: Tested 1 dependencies for known vulnerabilities, no vulnerable paths found.
```

After some debugging I found the line in the 'processGradleOutput' function that was causing the problem:
```
element === '';
```

This test was failing in the Dockerized Alpine and due to empty lines not correctly filtered the subsequent reduce function is interrupted before trying to parse the real dependencies. If I try to save the ```gradlew dependencies``` command to a file clearly the lines are not actually empty but contain a space before the newline (Notepad++ screenshot with "Show all characters" option enabled):

![gradew_dependencies](https://user-images.githubusercontent.com/3372532/47297335-13d23280-d615-11e8-9bac-4db7defc5be8.png)

I changed the empty element check with a regex that will match zero or one whitespace char plus the newline character. After the change the dependencies are correctly displayed in Alpine. Let me know if you need more info.