### PR TITLE
Feat/default configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ script:
 jobs:
   include:
     - stage: npm release
+      if: branch = master AND type != pull_request
       node_js: "8" # This *has* to be the "build leader"
-      script: skip
-      after_success:
-        - npm run semantic-release
+      script: npx semantic-release
 branches:
   only:
     - master

--- a/lib/gradle-plugin-parser.js
+++ b/lib/gradle-plugin-parser.js
@@ -1,0 +1,21 @@
+module.exports = {
+  parse: parse,
+};
+
+function parse(text) {
+  var pluginRe = /^[a-zA-Z0-9_\-\.]+@[0-9a-f]+$/;
+  if (text && text.length) {
+    return text.split('\n')
+      .map(trim)
+      .filter(function (line) {
+        return pluginRe.test(line);
+      });
+  }
+  return [];
+}
+
+function trim(text) {
+  // String.trim not available in es3
+  // see: https://goo.gl/EH6gh4
+  return text.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
 var os = require('os');
 var fs = require('fs');
 var path = require('path');
+var debug = require('debug')('snyk');
 var subProcess = require('./sub-process');
 var depParser = require('./gradle-dep-parser');
 var jarParser = require('./gradle-jar-parser');
+var pluginParser = require('./gradle-plugin-parser');
 var packageFormatVersion = 'mvn:0.0.1';
 
 module.exports = {
@@ -20,8 +22,14 @@ function inspect(root, targetFile, options) {
   }
   var command =  getCommand(root, targetFile);
   var subProject = options['gradle-sub-project'];
-  var args = buildArgs(root, targetFile, options.args, subProject);
-  return getPackage(root, command, args, subProject)
+  var args;
+  return setGradleConfiguration(root, targetFile, options)
+    .then(function () {
+      // options.args may have been mutated, now is the right time
+      // to build the dependency-checking command args
+      args = buildArgs(root, targetFile, options.args, subProject);
+      return getPackage(root, command, args, subProject);
+    })
     .then(function (pkg) {
     // opt-in with `jars` or `localjars` flag
       if (options.jars || options.localjars) {
@@ -82,6 +90,54 @@ function getJarList(root, targetFile, options) {
     args,
     {cwd: root})
     .then(jarParser.parse);
+}
+
+function getPluginList(root, targetFile) {
+  var args = buildArgs(root, targetFile);
+  args.shift(); // remove `dependencies` arg
+  args.push('-I ' + path.join(__dirname, 'init.gradle'), 'listAllPlugins');
+  return subProcess.execute(
+    getCommand(root, targetFile),
+    args,
+    {cwd: root})
+    .then(pluginParser.parse);
+}
+
+// make sure `options.args` includes the right gradle configuration.
+// mutates `options`!
+function setGradleConfiguration(root, targetFile, options) {
+  // Gradle configurations are subtle and very important
+  // with regards to dependencies. Choose as follows:
+  // 1. If `options.args` specifies a configuration, leave it as is.
+  // 2. Check for gradle plugins. If the 'java' plugin is used,
+  //    use the `default` configuration.
+  // 3. No explicit configuration in args, first configuration will be chosen!
+  var configurationArgIndex =
+    options.args && options.args.indexOf('--configuration');
+  if (configurationArgIndex !== undefined && configurationArgIndex >= 0) {
+    debug('Using explicit gradle configuration',
+      options.args[configurationArgIndex + 1]);
+    return Promise.resolve();
+  }
+
+  return getPluginList(root, targetFile)
+    .then(function (plugins) {
+      var hasJavaPlugin = plugins && plugins.some(function (plugin) {
+        return plugin.startsWith('org.gradle.api.plugins.JavaPlugin');
+      });
+      if (hasJavaPlugin) {
+        options.args = options.args || [];
+        options.args.push('--configuration', 'default');
+        debug('Java plugin detected, using default gradle configuration');
+      } else {
+        debug('Java plugin not detected, ' +
+          'not using any explicit gradle configuration');
+      }
+    })
+    .catch(function (error) {
+      debug('Error while checking for java plugin', error);
+      debug('Not using any explicit gradle configuration');
+    });
 }
 
 function getCommand(root, targetFile) {

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -1,4 +1,9 @@
 allprojects {
+  task listAllPlugins {
+    doLast {
+      project.plugins.each { println it }
+    }
+  }
   task listAllJars {
       doLast {
           configurations.compile.each { File file -> println file.name }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,12 @@
     "test": "npm run lint && npm run test-functional",
     "lint": "eslint -c .eslintrc lib test",
     "test-functional": "tap -R spec ./test/functional/*.test.js",
-    "test-system": "tap -R spec ./test/system/*.test.js",
-    "semantic-release": "semantic-release"
+    "test-system": "tap -R spec ./test/system/*.test.js"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
     "eslint": "^4.11.0",
-    "semantic-release": "^15",
     "sinon": "^2.4.1",
     "tap": "^12.0.1",
     "tap-only": "0.0.5"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "clone-deep": "^0.3.0"
+    "clone-deep": "^0.3.0",
+    "debug": "^3"
   }
 }

--- a/test/fixtures/checkstyle/build.gradle
+++ b/test/fixtures/checkstyle/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'java'
+apply plugin: 'checkstyle'
+
+ext {
+    checkstyleVersion = '8.10.1'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    runtime group: 'axis', name: 'axis', version: '1.4'
+}

--- a/test/functional/gradle-plugin-parser.test.js
+++ b/test/functional/gradle-plugin-parser.test.js
@@ -1,0 +1,70 @@
+var test = require('tap-only');
+var parse = require('../../lib/gradle-plugin-parser').parse;
+
+test('parse empty text', function (t) {
+  t.same(parse(''), [], 'empty list');
+  t.end();
+});
+
+test('parse normal text', function (t) {
+  var text = `org.gradle.api.plugins.HelpTasksPlugin@1517f633
+org.gradle.language.base.plugins.LifecycleBasePlugin@5560bcdf
+org.gradle.api.plugins.BasePlugin@6d9fb2d1
+org.gradle.api.plugins.ReportingBasePlugin@f2ce6b
+org.gradle.platform.base.plugins.ComponentBasePlugin@40298285
+org.gradle.language.base.plugins.LanguageBasePlugin@5bcb04cb
+org.gradle.platform.base.plugins.BinaryBasePlugin@21d1b321
+org.gradle.api.plugins.JavaBasePlugin@b25b095
+org.gradle.api.plugins.JavaPlugin@2f37f1f9
+org.gradle.api.plugins.quality.CheckstylePlugin@15639440`;
+
+  var expected = [
+    'org.gradle.api.plugins.HelpTasksPlugin@1517f633',
+    'org.gradle.language.base.plugins.LifecycleBasePlugin@5560bcdf',
+    'org.gradle.api.plugins.BasePlugin@6d9fb2d1',
+    'org.gradle.api.plugins.ReportingBasePlugin@f2ce6b',
+    'org.gradle.platform.base.plugins.ComponentBasePlugin@40298285',
+    'org.gradle.language.base.plugins.LanguageBasePlugin@5bcb04cb',
+    'org.gradle.platform.base.plugins.BinaryBasePlugin@21d1b321',
+    'org.gradle.api.plugins.JavaBasePlugin@b25b095',
+    'org.gradle.api.plugins.JavaPlugin@2f37f1f9',
+    'org.gradle.api.plugins.quality.CheckstylePlugin@15639440',
+  ];
+  t.same(parse(text), expected, 'plugin list');
+  t.end();
+});
+
+test('parse badly formatted text', function (t) {
+  var text = `:listAllPlugins
+org.gradle.api.plugins.HelpTasksPlugin@1517f633
+org.gradle.language.base.plugins.LifecycleBasePlugin@5560bcdf
+org.gradle.api.plugins.BasePlugin@6d9fb2d1
+org.gradle.api.plugins.ReportingBasePlugin@f2ce6b
+org.gradle.platform.base.plugins.ComponentBasePlugin@40298285
+org.gradle.language.base.plugins.LanguageBasePlugin@5bcb04cb
+org.gradle.platform.base.plugins.BinaryBasePlugin@21d1b321
+org.gradle.api.plugins.JavaBasePlugin@b25b095
+org.gradle.api.plugins.JavaPlugin@2f37f1f9
+org.gradle.api.plugins.quality.CheckstylePlugin@15639440
+
+BUILD SUCCESSFUL
+
+Total time: 3.62 secs
+
+This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.14.1/userguide/gradle_daemon.html`;
+
+  var expected = [
+    'org.gradle.api.plugins.HelpTasksPlugin@1517f633',
+    'org.gradle.language.base.plugins.LifecycleBasePlugin@5560bcdf',
+    'org.gradle.api.plugins.BasePlugin@6d9fb2d1',
+    'org.gradle.api.plugins.ReportingBasePlugin@f2ce6b',
+    'org.gradle.platform.base.plugins.ComponentBasePlugin@40298285',
+    'org.gradle.language.base.plugins.LanguageBasePlugin@5bcb04cb',
+    'org.gradle.platform.base.plugins.BinaryBasePlugin@21d1b321',
+    'org.gradle.api.plugins.JavaBasePlugin@b25b095',
+    'org.gradle.api.plugins.JavaPlugin@2f37f1f9',
+    'org.gradle.api.plugins.quality.CheckstylePlugin@15639440',
+  ];
+  t.same(parse(text), expected, 'plugin list');
+  t.end();
+});

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -161,6 +161,19 @@ test('only sub-project has deps', function (t) {
     .catch(t.fail);
 });
 
+test('default configuration is used by default', function (t) {
+  return plugin.inspect('.',
+    path.join(__dirname, '..', 'fixtures', 'checkstyle', 'build.gradle'))
+    .then(function (result) {
+      t.ok(result.package.dependencies['axis:axis'], 'axis:axis found');
+      t.equal(result.package.dependencies['axis:axis'].version,
+        '1.4',
+        'correct version found');
+      t.end();
+    })
+    .catch(t.fail);
+});
+
 function stubPlatform(platform, t) {
   sinon.stub(os, 'platform')
     .callsFake(function () {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

* Tidies up `semantic-release` flow, removes `semantic-release` as a devDep
* Runs an extra `gradle` command to list the plugins in the analyzed project
* If the `'java'` gradle plugin is included in the analyzed project, AND no explicit gradle configuration is set via `options.args`, then the `default` gradle configuration will be used for our analysis.

Why? Good question.

Our current logic parses the dependencies of the *first* configuration with any dependencies out of the list of all relevant configurations as they are printed by the `gradle dependencies` command. This logic is quite arbitrary and causes some silent mistakes for our users, see #19 and #22 for example.

A user pointed out that the `default` gradle configuration would be more sensible as a fallback. We believe that the `default` gradle configuration is only valid with the `'java'` plugin, hence this PR.

We're totally open to other approaches and would like to crowd-source them from our savvy gradle users. Calling on @quynh-axiadids, @Vortim as well as @pastjean, would be very grateful for your input here.

An alternative approach for implicit configuration selection was discussed internally @snyksec, and it looks like this:
1. Run `gradle dependencies` like we do today, collect output of all relevant configurations
2. Take the following configurations only, in the exact order as they appear here:
```
runtimeClasspath
runtime
compileClasspath
compile
default
```
3. Filter out those that have no dependencies
4. Analyze the *first* of the remaining configurations.

We'd appreciate any comments! 🙏 