### PR TITLE
fix: support target file paths with spaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,12 @@ function buildArgs(root, targetFile, gradleArgs, subProject) {
       throw new Error('File not found: "' + targetFile + '"');
     }
     args.push('--build-file');
-    args.push('"' + targetFile + '"');
+
+    var formattedTargetFile = targetFile;
+    if (/\s/.test(targetFile)) { // checking for whitespaces
+      formattedTargetFile = '\'' + targetFile + '\'';
+    }
+    args.push(formattedTargetFile);
   }
   if (gradleArgs) {
     args = args.concat(gradleArgs);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

this commit expands on the work done in 66de57e6f0a85e9bb461c1848984608419340560 to handle more cases by using single quotes instead of double, and only if whitespaces are present in the target file, as I believe to be the standard in POSIX.
