### PR TITLE
fix:trimming off trailing (c) - resolution state

### DIFF
--- a/lib/gradle-dep-parser.js
+++ b/lib/gradle-dep-parser.js
@@ -71,7 +71,8 @@ function processGradleOutput(text) {
 
       // trim (n) - Not resolved (configuration is not meant to be resolved)
       element = element.split(' (n)')[0];
-
+      // trim (c) - RESOLVED_CONSTRAINT
+      element = element.split(' (c)')[0];
       return element;
     });
   return {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "eslint": "^4.11.0",
     "semantic-release": "^15",
     "sinon": "^2.4.1",
-    "tap": "^12.0.1",
-    "tap-only": "0.0.5"
+    "tap": "github:snyk/node-tap#alternative-runtimes"
   },
   "dependencies": {
     "clone-deep": "^0.3.0"

--- a/test/fixtures/no wrapper/gradle-dependencies-output.txt
+++ b/test/fixtures/no wrapper/gradle-dependencies-output.txt
@@ -32,7 +32,7 @@ compile - Dependencies for source set 'main' (deprecated, use 'implementation ' 
      |         |    \--- com.google.guava:guava:18.0
      |         \--- net.sf.kxml:kxml2:2.3.0
      +--- com.android.tools:sdklib:25.3.0
-     |    +--- com.android.tools.layoutlib:layoutlib-api:25.3.0
+     |    +--- com.android.tools.layoutlib:layoutlib-api:25.3.0 (c)
      |    |    +--- com.android.tools:common:25.3.0 (*)
      |    |    +--- net.sf.kxml:kxml2:2.3.0
      |    |    +--- com.android.tools:annotations:25.3.0
@@ -57,9 +57,9 @@ compile - Dependencies for source set 'main' (deprecated, use 'implementation ' 
      |    +--- com.android.tools:sdklib:25.3.0 (*)
      |    +--- com.android.tools.build:builder-test-api:2.3.0 (*)
      |    +--- com.android.tools.build:builder-model:2.3.0 (*)
-     |    +--- org.bouncycastle:bcpkix-jdk15on:1.48
-     |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48
-     |    \--- org.bouncycastle:bcprov-jdk15on:1.48
+     |    +--- org.bouncycastle:bcpkix-jdk15on:1.48 (c)
+     |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
+     |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
      +--- com.android.tools:common:25.3.0 (*)
      +--- com.android.tools.build:manifest-merger:25.3.0
      |    +--- com.android.tools:common:25.3.0 (*)
@@ -87,7 +87,7 @@ compile - Dependencies for source set 'main' (deprecated, use 'implementation ' 
      |    \--- com.google.guava:guava:18.0
      +--- com.squareup:javawriter:2.5.0
      +--- org.bouncycastle:bcpkix-jdk15on:1.48 (*)
-     +--- org.bouncycastle:bcprov-jdk15on:1.48
+     +--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
      +--- org.ow2.asm:asm:5.0.4
      \--- org.ow2.asm:asm-tree:5.0.4
           \--- org.ow2.asm:asm:5.0.4
@@ -132,9 +132,9 @@ runtime - Runtime dependencies for source set 'main' (deprecated, use 'runtimeOn
      |    +--- com.android.tools:sdklib:25.3.0 (*)
      |    +--- com.android.tools.build:builder-test-api:2.3.0 (*)
      |    +--- com.android.tools.build:builder-model:2.3.0 (*)
-     |    +--- org.bouncycastle:bcpkix-jdk15on:1.48
-     |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48
-     |    \--- org.bouncycastle:bcprov-jdk15on:1.48
+     |    +--- org.bouncycastle:bcpkix-jdk15on:1.48 (c)
+     |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
+     |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
      +--- com.android.tools:common:25.3.0 (*)
      +--- com.android.tools.build:manifest-merger:25.3.0
      |    +--- com.android.tools:common:25.3.0 (*)
@@ -207,9 +207,9 @@ testCompile - Dependencies for source set 'test' (deprecated, use 'testImplement
 |    |    +--- com.android.tools:sdklib:25.3.0 (*)
 |    |    +--- com.android.tools.build:builder-test-api:2.3.0 (*)
 |    |    +--- com.android.tools.build:builder-model:2.3.0 (*)
-|    |    +--- org.bouncycastle:bcpkix-jdk15on:1.48
-|    |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48
-|    |    \--- org.bouncycastle:bcprov-jdk15on:1.48
+|    |    +--- org.bouncycastle:bcpkix-jdk15on:1.48 (c)
+|    |    |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
+|    |    \--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
 |    +--- com.android.tools:common:25.3.0 (*)
 |    +--- com.android.tools.build:manifest-merger:25.3.0
 |    |    +--- com.android.tools:common:25.3.0 (*)
@@ -237,7 +237,7 @@ testCompile - Dependencies for source set 'test' (deprecated, use 'testImplement
 |    |    \--- com.google.guava:guava:18.0
 |    +--- com.squareup:javawriter:2.5.0
 |    +--- org.bouncycastle:bcpkix-jdk15on:1.48 (*)
-|    +--- org.bouncycastle:bcprov-jdk15on:1.48
+|    +--- org.bouncycastle:bcprov-jdk15on:1.48 (c)
 |    +--- org.ow2.asm:asm:5.0.4
 |    \--- org.ow2.asm:asm-tree:5.0.4
 |         \--- org.ow2.asm:asm:5.0.4

--- a/test/functional/gradle-dep-parser.test.js
+++ b/test/functional/gradle-dep-parser.test.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var test = require('tap-only');
+var test = require('tap').test;
 var parse = require('../../lib/gradle-dep-parser').parse;
 var fixturePath = path.join(__dirname, '..', 'fixtures');
 
@@ -72,7 +72,7 @@ test('parse a `gradle dependencies` output', function (t) {
 });
 
 test('parse a `gradle dependencies` output', function (t) {
-  return t.test('handle (n) marker', function (t) {
+  return t.test('handle (n) and (c)  marker', function (t) {
     t.plan(1);
     var gradleOutput = fs.readFileSync(path.join(
       fixturePath, 'api-configuration', 'gradle-dependencies-output.txt'),
@@ -105,4 +105,26 @@ test('parse a `gradle dependencies` output', function (t) {
       },
     }, 'handles version selection correctly');
   });
+});
+
+
+test('parse a `gradle dependencies` output', function (t) {
+  t.plan(2);
+  var gradleOutput = fs.readFileSync(path.join(
+    fixturePath, 'no wrapper', 'gradle-dependencies-output.txt'), 'utf8');
+  var depTree = parse(gradleOutput, 'myPackage@1.0.0');
+
+  t.equal(
+    depTree['com.android.tools.build:builder']
+      .dependencies['com.android.tools:sdk-common']
+      .dependencies['org.bouncycastle:bcpkix-jdk15on']
+      .dependencies['org.bouncycastle:bcprov-jdk15on'].version,
+    '1.48', 'resolved ommitted dependency version');
+
+  t.equal(
+    depTree['com.android.tools.build:builder']
+      .dependencies['com.android.tools:sdk-common']
+      .dependencies['org.bouncycastle:bcpkix-jdk15on']
+      .dependencies['org.bouncycastle:bcprov-jdk15on'].name,
+    'org.bouncycastle:bcprov-jdk15on', 'resolved ommitted dependency name');
 });

--- a/test/functional/gradle-jar-parser.test.js
+++ b/test/functional/gradle-jar-parser.test.js
@@ -1,4 +1,4 @@
-var test = require('tap-only');
+var test = require('tap').test;
 var parse = require('../../lib/gradle-jar-parser').parse;
 
 test('parse empty text', function (t) {

--- a/test/functional/gradle-plugin.test.js
+++ b/test/functional/gradle-plugin.test.js
@@ -1,7 +1,8 @@
-var test = require('tap-only');
+var test = require('tap').test;
 var plugin = require('../../lib').__tests;
 
 test('check build args with array', function (t) {
+  t.plan(1);
   var result = plugin.buildArgs(null, null, [
     '--build-file',
     'build.gradle',
@@ -20,6 +21,7 @@ test('check build args with array', function (t) {
 });
 
 test('check build args with string', function (t) {
+  t.plan(1);
   var result = plugin.buildArgs(null, null,
     '--build-file build.gradle --configuration compile');
   t.deepEqual(result, [

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -1,6 +1,6 @@
 var os = require('os');
 var path = require('path');
-var test = require('tap-only');
+var test = require('tap').test;
 var sinon = require('sinon');
 var plugin = require('../../lib');
 var subProcess = require('../../lib/sub-process');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
trims off the trailing "(c)" that gradle dependencies command outputs in some cases, leading to missing out vulns.


#### How should this be manually tested?
run test/monitor a gradle project that contains (c) in one of it's dependency resolution. specially if it's a dependency with issues.
it will result on missing vulns on those dependencies. as we don't recognise the right package name.


#### What are the relevant tickets?
