### PR TITLE
fix: add targetFile to inspect output for build.gradle.kts files support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ function inspect(root, targetFile, options) {
         plugin: {
           name: 'bundled:gradle',
           runtime: 'unknown',
+          targetFile,
         },
         package: pkg,
       };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Add `targetFile` to `inspect` output for build.gradle.kts files support.

#### Any background context you want to provide?

https://github.com/snyk/snyk/pull/395

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-398
