### PR TITLE
feat: Only send targetFile for kotlin to avoid breaking overrides & changing existing project names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function inspect(root, targetFile, options) {
         plugin: {
           name: 'bundled:gradle',
           runtime: 'unknown',
-          targetFile,
+          targetFile: (path.basename(targetFile) === 'build.gradle.kts') ? targetFile : undefined,
         },
         package: pkg,
       };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Don't send targetFile for Groovy gradle projects as it is used to construct project name and will create a new project for existing users

