### PR TITLE
refactor: convert to Typescript (no proper lint, no types yet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ Additional command line arguments to Gradle can be provided after `--`, for exam
 ## Under the hood
 
 See `lib/init.gradle` for the Groovy script injected in Gradle builds to gather and resolve the dependencies.
+
+## Developer notes
+
+Minimum supported version of Node.js is 4.
+
+It does not support ts-node (required to run tests from `.ts` files), so we have to run `.js` tests from `./dist` 
+for now.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,19 +1,17 @@
-var os = require('os');
-var fs = require('fs');
-var path = require('path');
-var subProcess = require('./sub-process');
+import * as os from 'os';
+import * as fs from 'fs';
+import * as  path from 'path';
+import * as subProcess from './sub-process';
+
 var packageFormatVersion = 'mvn:0.0.1';
 
-module.exports = {
-  inspect: inspect,
-};
-
-module.exports.__tests = {
+// tslint:disable-next-line
+export const __tests = {
   buildArgs: buildArgs,
   extractJsonFromScriptOutput: extractJsonFromScriptOutput,
 };
 
-function inspect(root, targetFile, options) {
+export function inspect(root, targetFile, options?) {
   if (!options) {
     options = {dev: false};
   }
@@ -42,7 +40,7 @@ function extractJsonFromScriptOutput(stdoutText) {
       jsonLine = l.substr(9);
     }
   });
-  return JSON.parse(jsonLine);
+  return JSON.parse(jsonLine!);
 }
 
 function getAllDeps(root, targetFile, options, subProject) {
@@ -62,8 +60,8 @@ function getAllDeps(root, targetFile, options, subProject) {
     args[i] = a.replace(/^--configuration[= ]/, '-Pconfiguration=');
     // Transform --configuration foo
     if (a === '--configuration') {
-      args[i] = '-Pconfiguration=' + args[i+1];
-      args[i+1] = '';
+      args[i] = '-Pconfiguration=' + args[i + 1];
+      args[i + 1] = '';
     }
   });
 
@@ -81,7 +79,7 @@ function getAllDeps(root, targetFile, options, subProject) {
         packageName += '/' + subProject;
         depTree = allProjectDeps[subProject];
       } else {
-        depTree = allProjectDeps[allProjectDeps['$rootProject']];
+        depTree = allProjectDeps[allProjectDeps.$rootProject];
       }
       var packageVersion = '0.0.0';
       return {
@@ -119,7 +117,7 @@ function getCommand(root, targetFile) {
 }
 
 function buildArgs(root, targetFile, gradleArgs) {
-  var args = [];
+  var args: string[] = [];
   args.push('snykResolvedDepsJson', '-q');
   if (targetFile) {
     if (!fs.existsSync(path.resolve(root, targetFile))) {

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,7 +1,7 @@
-var childProcess = require('child_process');
+import * as childProcess from 'child_process';
 
-module.exports.execute = function (command, args, options) {
-  var spawnOptions = {shell: true};
+export function execute(command, args, options) {
+  var spawnOptions: childProcess.SpawnOptions = {shell: true};
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
@@ -25,4 +25,4 @@ module.exports.execute = function (command, args, options) {
       resolve(stdout || stderr);
     });
   });
-};
+}

--- a/package.json
+++ b/package.json
@@ -6,26 +6,31 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-gradle-plugin"
   },
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "build": "tsc",
     "test": "npm run lint && npm run test-functional && npm run test-system",
-    "lint": "eslint -c .eslintrc lib test",
-    "test-functional": "tap -R spec ./test/functional/*.test.js",
-    "test-system": "tap -R spec --timeout=180 ./test/system/*.test.js",
+    "lint": "tslint --project tsconfig.json --format stylish",
+    "test-functional": "tap -R spec ./dist/test/functional/*.test.js",
+    "test-system": "tap -R spec --timeout=180 ./dist/test/system/*.test.js",
     "semantic-release": "semantic-release"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint": "^4.11.0",
+    "@types/node": "^4.9.1",
+    "@types/sinon": "^7.0.10",
     "semantic-release": "^15",
     "sinon": "^2.4.1",
-    "tap": "github:snyk/node-tap#alternative-runtimes"
+    "tap": "^12.5",
+    "tslint": "^5.14.0",
+    "typescript": "^3.3.4000"
   },
   "dependencies": {
-    "clone-deep": "^0.3.0"
+    "clone-deep": "^0.3.0",
+    "tslib": "^1.9.3"
   }
 }

--- a/test/functional/gradle-plugin.test.ts
+++ b/test/functional/gradle-plugin.test.ts
@@ -1,5 +1,5 @@
-var test = require('tap').test;
-var plugin = require('../../lib').__tests;
+import {test} from 'tap';
+import {__tests as plugin} from '../../lib';
 
 test('check build args with array', function (t) {
   t.plan(1);
@@ -36,8 +36,11 @@ test('check build args with string', function (t) {
 
 test('extractJsonFromScriptOutput', function (t) {
   t.plan(1);
-  var result = plugin.extractJsonFromScriptOutput('Mr Gradle says hello\nla dee da, la dee da\nJSONDEPS {"hello": "world"}\nsome other noise');
-  t.deepEqual(result, {'hello': 'world'});
+  var result = plugin.extractJsonFromScriptOutput(`Mr Gradle says hello
+la dee da, la dee da
+JSONDEPS {"hello": "world"}
+some other noise`);
+  t.deepEqual(result, {hello: 'world'});
   t.end();
 });
 

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -1,9 +1,9 @@
-var os = require('os');
-var path = require('path');
-var test = require('tap').test;
-var sinon = require('sinon');
-var plugin = require('../../lib');
-var subProcess = require('../../lib/sub-process');
+import * as os from 'os';
+import * as path from 'path';
+import {test} from 'tap';
+import {stub, SinonStub} from 'sinon';
+import * as plugin from '../../lib';
+import * as subProcess from '../../lib/sub-process';
 
 var rootNoWrapper = path.join(
   __dirname, '..', 'fixtures', 'no wrapper');
@@ -54,7 +54,7 @@ test('windows without wrapper', function (t) {
   return plugin.inspect(rootNoWrapper, 'build.gradle')
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       t.same(cmd, 'gradle', 'invokes gradle directly');
     });
 });
@@ -68,7 +68,7 @@ test('darwin without wrapper', function (t) {
   return plugin.inspect(rootNoWrapper, 'build.gradle')
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       t.same(cmd, 'gradle', 'invokes gradle directly');
     });
 });
@@ -82,7 +82,7 @@ test('windows with wrapper', function (t) {
   return plugin.inspect(rootWithWrapper, 'build.gradle')
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       var expectedCmd = path.join(
         __dirname, '..', 'fixtures', 'with-wrapper', 'gradlew.bat');
       t.same(cmd, expectedCmd, 'invokes wrapper bat');
@@ -98,7 +98,7 @@ test('darwin with wrapper', function (t) {
   return plugin.inspect(rootWithWrapper, 'build.gradle')
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       var expectedCmd = path.join(
         __dirname, '..', 'fixtures', 'with-wrapper', 'gradlew');
       t.same(cmd, expectedCmd, 'invokes wrapper script');
@@ -114,7 +114,7 @@ test('windows with wrapper in root', function (t) {
   return plugin.inspect(subWithWrapper, path.join('app', 'build.gradle'))
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       var expectedCmd = path.join(
         __dirname, '..', 'fixtures', 'with-wrapper-in-root', 'gradlew.bat');
       t.same(cmd, expectedCmd, 'invokes wrapper bat');
@@ -130,7 +130,7 @@ test('darwin with wrapper in root', function (t) {
   return plugin.inspect(subWithWrapper, path.join('app', 'build.gradle'))
     .then(t.fail)
     .catch(function () {
-      var cmd = subProcess.execute.getCall(0).args[0];
+      var cmd = (subProcess.execute as SinonStub).getCall(0).args[0];
       var expectedCmd = path.join(
         __dirname, '..', 'fixtures', 'with-wrapper-in-root', 'gradlew');
       t.same(cmd, expectedCmd, 'invokes wrapper script');
@@ -250,17 +250,17 @@ test('malformed build.gradle', function (t) {
 });
 
 function stubPlatform(platform, t) {
-  sinon.stub(os, 'platform')
+  stub(os, 'platform')
     .callsFake(function () {
       return platform;
     });
-  t.teardown(os.platform.restore);
+  t.teardown((os.platform as SinonStub).restore);
 }
 
 function stubSubProcessExec(t) {
-  sinon.stub(subProcess, 'execute')
+  stub(subProcess, 'execute')
     .callsFake(function () {
       return Promise.reject(new Error('abort'));
     });
-  t.teardown(subProcess.execute.restore);
+  t.teardown((subProcess.execute as SinonStub).restore);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+      "outDir": "./dist",
+      "pretty": true,
+      "target": "es5",
+      "lib": [
+        "es5",
+        "es2015.promise",
+      ],
+      "module": "commonjs",
+      "allowJs": false,
+      "sourceMap": true,
+      "strict": true,
+      "importHelpers": true,
+      "noImplicitAny": false // Needed to compile tap and ansi-escapes
+  },
+  "include": [
+      "./lib/**/*",
+      "./test/**/*",
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,30 @@
+{
+  "extends": "tslint:recommended",
+  "rules": {
+      "max-line-length": {
+          "options": [120]
+      },
+      "trailing-comma": [true, {"multiline": "always"}],
+      "triple-equals": true,
+      "curly": true,
+      "indent": [true, "spaces", 2],
+      "interface-name": false,
+      "no-use-before-declare": true,
+      "object-literal-sort-keys": false,
+      "ordered-imports": false,
+      // "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+      "semicolon": [true, "always"],
+      "no-console": [false],
+      // Temporarily disabled lints to keep the diff minimal
+      // TODO(kyegupov): clean up TS code and enable those
+      "quotemark": [false],
+      "no-default-export": true,
+      "no-var-keyword": false,
+      "prefer-const": false,
+      "only-arrow-functions": false,
+      "space-before-function-paren": false,
+      "no-shadowed-variable": false,
+      "object-literal-shorthand": false,
+      "prefer-for-of": false
+  }
+}


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Converts the project to Typescript.
Most of the tslint rules disabled for now to keep the diff minimal.
No type definitions added yet.

#### Any background context you want to provide?

We are working on modernizing Gradle support. To make sense of the logic we could use some type definitions.

#### What are the relevant tickets?

Motivated by https://snyksec.atlassian.net/browse/BST-508
