### PR TITLE
test: run tests against multiple Gradle versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ node_js:
   - "8"
   - "6"
   - "4"
+env:
+  # test against final major Gradle versions
+  - GRADLE_VERSION=3.5.1
+  - GRADLE_VERSION=4.10.3
+  - GRADLE_VERSION=5.3.1
 cache:
   directories:
     - node_modules
@@ -20,7 +25,12 @@ before_install:
   - sudo apt-get install -y openjdk-8-jdk --no-install-recommends
   - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  # sdkman helps to install different gradle versions
+  - curl -s "https://get.sdkman.io" | bash
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
 script:
+  - sdk install gradle $GRADLE_VERSION
   - npm test
 jobs:
   include:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -193,7 +193,8 @@ function buildArgs(root, targetFile, gradleArgs: string[]) {
 
   // Parallel builds can cause race conditions and multiple JSONDEPS lines in the output
   // Gradle 4.3.0+ has `--no-parallel` flag, but we want to support older versions.
-  args.push('-Dorg.gradle.parallel=false');
+  // Not `=false`, because https://github.com/gradle/gradle/issues/1827
+  args.push('-Dorg.gradle.parallel=');
 
   if (gradleArgs) {
     args.push(...gradleArgs);

--- a/test/functional/gradle-plugin.test.ts
+++ b/test/functional/gradle-plugin.test.ts
@@ -13,7 +13,7 @@ test('check build args with array', (t) => {
     'snykResolvedDepsJson',
     '-q',
     '--no-daemon',
-    '-Dorg.gradle.parallel=false',
+    '-Dorg.gradle.parallel=',
     '--build-file',
     'build.gradle',
     '--configuration',
@@ -30,7 +30,7 @@ test('check build args with string', (t) => {
     'snykResolvedDepsJson',
     '-q',
     '--no-daemon',
-    '-Dorg.gradle.parallel=false',
+    '-Dorg.gradle.parallel=',
     '--build-file build.gradle --configuration compile',
   ]);
   t.end();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Gradle is hard. Let's run our tests against several different Gradle versions to minimize a possibility of introducing a regression.
