### PR TITLE
chore: switch AppVeyor build to test against Node.js 10 instead of 4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ cache:
 
 environment:
   matrix:
+    - nodejs_version: "10"
     - nodejs_version: "8"
     - nodejs_version: "6"
-    - nodejs_version: "4"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

We've dropping Node.4 support for Snyk CLI.
