### PR TITLE
chore: switch back to non-forked node-tap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "10"
   - "8"
   - "6"
-  - "4"
 env:
   # test against final major Gradle versions
   - GRADLE_VERSION=3.5.1
@@ -18,7 +17,7 @@ cache:
     - node_modules
     - $HOME/.gradle
     - .gradle
-before_install:    
+before_install:
   # some of our tests use Gradle 3.0, which fails on Java 9+
   - sudo add-apt-repository -y ppa:openjdk-r/ppa
   - sudo apt-get -qq update

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -196,8 +196,8 @@ async function getAllDeps(root, targetFile, options): Promise<JsonDepsScriptResu
   // TODO: move to buildArgs, adjust tests
   let initGradlePath: string | null = null;
   if (/index.js$/.test(__filename)) {
-    // running from ./dist/lib
-    initGradlePath = path.join(__dirname, '../../lib/init.gradle');
+    // running from ./dist
+    initGradlePath = path.join(__dirname, '../lib/init.gradle');
   } else if (/index.ts$/.test(__filename)) {
     // running from ./lib
     initGradlePath = path.join(__dirname, 'init.gradle');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-gradle-plugin"
   },
-  "main": "dist/lib/index.js",
+  "main": "dist/index.js",
   "directories": {
     "test": "test"
   },
@@ -19,9 +19,9 @@
     "lint": "tslint --project tsconfig.json --format stylish",
     "prepare": "npm run build",
     "semantic-release": "semantic-release",
-    "test": "npm run build && npm run lint && npm run test-functional && npm run test-system",
-    "test-functional": "tap -R spec ./dist/test/functional/*.test.js",
-    "test-system": "tap -R spec --timeout=180 ./dist/test/system/*.test.js"
+    "test": "npm run lint && npm run test-functional && npm run test-system",
+    "test-functional": "tap -R spec ./test/functional/*.test.[tj]s",
+    "test-system": "tap -R spec --timeout=180 ./test/system/*.test.[tj]s"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
@@ -31,7 +31,7 @@
     "@types/tmp": "0.0.34",
     "semantic-release": "^15",
     "sinon": "^2.4.1",
-    "tap": "github:snyk/node-tap#alternative-runtimes",
+    "tap": "^12.6.1",
     "tslint": "^5.14.0",
     "typescript": "^3.3.4000"
   },

--- a/test/common.ts
+++ b/test/common.ts
@@ -4,8 +4,8 @@ import {stub, SinonStub} from 'sinon';
 import * as subProcess from '../lib/sub-process';
 
 export function fixtureDir(f: string): string {
-  // Assuming current directory is ./dist/test
-  return path.join(__dirname, '../../test/fixtures', f);
+  // Assuming current directory is ./test
+  return path.join(__dirname, 'fixtures', f);
 }
 
 export function stubPlatform(platform, t) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
       "noImplicitAny": false // Needed to compile tap and ansi-escapes
   },
   "include": [
-      "./lib/**/*",
-      "./test/**/*",
+      "./lib/**/*"
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- node-tap has added typescript/ts-node support, so let's use it

#### Any background context you want to provide?

- removing `test` from tsconfig `include` has change the output folder structure

#### To Check

- ~make sure Windows tests run~ They do!

<img width="596" alt="Screenshot 2019-04-01 at 18 43 34" src="https://user-images.githubusercontent.com/59090/55348014-18e1ba80-54ae-11e9-8a6e-d7ae6bd93ec1.png">
