### PR TITLE
fix: work around non-mergeable configs in Android builds

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -4,7 +4,7 @@ import groovy.json.JsonOutput
 // generate a merged configuration of all the available configurations,
 // and then list the dependencies as a tree.
 
-// It's the responsibility of the caller to pick the project(s) they are 
+// It's the responsibility of the caller to pick the project(s) they are
 // interested in from the results.
 
 // CLI usages:
@@ -44,7 +44,7 @@ import groovy.json.JsonOutput
 // only ever run it once, for the "starting" project.
 def snykMergedDepsConfExecuted = false
 allprojects { everyProj ->
-    task snykResolvedDepsJson { 
+    task snykResolvedDepsJson {
         def onlyConf = project.hasProperty('configuration') ? configuration : null
 
         def depsToDict
@@ -66,17 +66,26 @@ allprojects { everyProj ->
             def result = ['defaultProject': task.project.name, 'projects': projectsDict]
             if (!snykMergedDepsConfExecuted) {
                 allprojects.each { proj ->
+                    def snykConf = null
                     if (proj.configurations.size() > 0) {
-                        if (proj.configurations.findAll({ it.name == 'snykMergedDepsConf'}).size() == 0) {
-                            def snykConf = proj.configurations.create('snykMergedDepsConf')
+                        if (onlyConf != null) {
+                            // We select one existing configuration, with its attributes.
+                            snykConf = proj.configurations.getByName(onlyConf)
+                        } else if (proj.configurations.findAll({ it.name == 'snykMergedDepsConf'}).size() == 0) {
+                            // We create a new, "merged" configuration here. It has no attributes, which might be
+                            // a problem for Android builds, where a resolution of a dependency "variant"
+                            // is often dependent on configuration attributes (such as BuildType or Usage).
+                            snykConf = proj.configurations.create('snykMergedDepsConf')
                             proj.configurations
                                 .findAll({ it.name != 'snykMergedDepsConf' && (onlyConf == null || it.name == onlyConf) })
                                 .each { snykConf.extendsFrom(it) }
-                            projectsDict[proj.name] = [
-                                'targetFile': findProject(proj.path).buildFile.toString(),
-                                'depDict': depsToDict(snykConf.resolvedConfiguration.firstLevelModuleDependencies)
-                            ]
                         }
+                    }
+                    if (snykConf != null) {
+                        projectsDict[proj.name] = [
+                            'targetFile': findProject(proj.path).buildFile.toString(),
+                            'depDict': depsToDict(snykConf.resolvedConfiguration.firstLevelModuleDependencies)
+                        ]
                     } else {
                         projectsDict[proj.name] = [
                             'targetFile': findProject(proj.path).buildFile.toString()

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,7 @@
+## Android build issues
+
+Since installing Android SDK is quite a hassle, there's no automated test for the Android Build Type problem
+(https://snyksec.atlassian.net/browse/BST-528).
+
+Instead, please install Androd Studio or SDK on your own
+and run `snyk test` on https://github.com/snyk-fixtures/android-cannot-auto-resolve to test


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team
- [x] Example fixture added (not automated tests)

#### What does this PR do?

* when specifying a concrete configuration, preserve its attributes
* if failing due to unmergeable configurations, display actionable suggestions for the user

#### Where should the reviewer start?

index.ts and the message there; init.gradle; test/fixtures/android-cannot-auto-resolve/app/build.gradle 

#### How should this be manually tested?

run snyk test on various Gradle projects (android and not)

#### Any background context you want to provide?

Should be all in the error message and comments.
If anything is not clear - let's add the comments.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-528

