### PR TITLE
fix: handle circular dependencies in Gradle scans

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -47,16 +47,22 @@ allprojects { everyProj ->
     task snykResolvedDepsJson {
         def onlyConf = project.hasProperty('configuration') ? configuration : null
 
+        // currentChain is a protection against dependency cycles, which are perfectly normal in Java/Gradle world
         def depsToDict
-        depsToDict = { deps ->
+        depsToDict = { Iterable deps, Set currentChain ->
             def res = [:]
             deps.each { d ->
-                def row = ['name': "$d.moduleGroup:$d.moduleName", 'version': d.moduleVersion]
-                def subDeps = depsToDict(d.children)
-                if (subDeps.size() > 0) {
-                    row['dependencies'] = subDeps
+                def depName = "$d.moduleGroup:$d.moduleName"
+                if (!currentChain.contains(depName)) {
+                    def row = ['name': depName, 'version': d.moduleVersion]
+                    currentChain.add(depName)
+                    def subDeps = depsToDict(d.children, currentChain)
+                    currentChain.remove(depName)
+                    if (subDeps.size() > 0) {
+                        row['dependencies'] = subDeps
+                    }
+                    res[row['name']] = row
                 }
-                res[row['name']] = row
             }
             return res
         }
@@ -84,7 +90,7 @@ allprojects { everyProj ->
                     if (snykConf != null) {
                         projectsDict[proj.name] = [
                             'targetFile': findProject(proj.path).buildFile.toString(),
-                            'depDict': depsToDict(snykConf.resolvedConfiguration.firstLevelModuleDependencies)
+                            'depDict': depsToDict(snykConf.resolvedConfiguration.firstLevelModuleDependencies, new HashSet())
                         ]
                     } else {
                         projectsDict[proj.name] = [

--- a/test/fixtures/multi-project-dependency-cycle/build.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+    compile project(':subproj')
+}

--- a/test/fixtures/multi-project-dependency-cycle/settings.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/settings.gradle
@@ -1,0 +1,5 @@
+rootProject.name = 'root-proj'
+
+include 'subproj'
+
+

--- a/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
@@ -1,0 +1,50 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'com.google.guava:guava:18.0'
+  compile 'batik:batik-dom:1.6'
+  compile 'commons-discovery:commons-discovery:0.2'
+  compileOnly 'axis:axis:1.3'
+  compile 'com.android.tools.build:builder:2.3.0'
+  compile project(':')
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+// To specify a license in the pom:
+install {
+  repositories.mavenInstaller {
+    pom.project {
+      licenses {
+        license {
+          name 'The Apache Software License, Version 2.0'
+          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          distribution 'repo'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fix for StackOverflowError when scanning projects with dependency cycles.
Terminate the recursive function when encountering a cycle. 

#### Where should the reviewer start?

init.gradle

#### How should this be manually tested?

See the added fixture.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-575

