### PR TITLE
feat: if a missing configuration is specified, display the names of a…

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -76,7 +76,13 @@ allprojects { everyProj ->
                     if (proj.configurations.size() > 0) {
                         if (onlyConf != null) {
                             // We select one existing configuration, with its attributes.
-                            snykConf = proj.configurations.getByName(onlyConf)
+                            try {
+                                snykConf = proj.configurations.getByName(onlyConf)
+                            } catch (e) {
+                                throw new RuntimeException('Configuration not found: ' + onlyConf +
+                                    ', available configurations for project ' + proj + ': '
+                                     + proj.configurations.collect { it.name })
+                            }
                         } else if (proj.configurations.findAll({ it.name == 'snykMergedDepsConf'}).size() == 0) {
                             // We create a new, "merged" configuration here. It has no attributes, which might be
                             // a problem for Android builds, where a resolution of a dependency "variant"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

If the user uses the (kinda undocumented) `--configuration` flag with a wrong configuration name, suggest existing ones.

#### What are the relevant tickets?

https://snyk.zendesk.com/agent/tickets/344


![image](https://user-images.githubusercontent.com/502156/57015325-38cee000-6c0c-11e9-9fb2-7890b1f13663.png)
