### PR TITLE
fix: make the injected script scan only one sub-project

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -9,7 +9,7 @@ import groovy.json.JsonOutput
 
 // CLI usages:
 // gradle -q -I init.gradle snykResolvedDepsJson
-// gradle -q -I init.gradle snykResolvedDepsJson -Pconfiguration=specificConf
+// gradle -q -I init.gradle snykResolvedDepsJson -Pconfiguration=specificConf -PonlySubProject=sub-project
 
 // (-q to have clean output, -P supplies args as per https://stackoverflow.com/a/48370451)
 
@@ -45,6 +45,7 @@ import groovy.json.JsonOutput
 def snykMergedDepsConfExecuted = false
 allprojects { everyProj ->
     task snykResolvedDepsJson {
+        def onlyProj = project.hasProperty('onlySubProject') ? onlySubProject : null
         def onlyConf = project.hasProperty('configuration') ? configuration : null
 
         // currentChain is a protection against dependency cycles, which are perfectly normal in Java/Gradle world
@@ -69,9 +70,17 @@ allprojects { everyProj ->
 
         doLast { task ->
             def projectsDict = [:]
-            def result = ['defaultProject': task.project.name, 'projects': projectsDict]
+            def defaultProjectName = task.project.name
+            def result = ['defaultProject': defaultProjectName, 'projects': projectsDict]
             if (!snykMergedDepsConfExecuted) {
-                allprojects.each { proj ->
+
+                def shouldScanProject = {
+                    onlyProj == null ||
+                    (onlyProj == '.' && it.name == defaultProjectName) ||
+                    it.name == onlyProj
+                }
+
+                allprojects.findAll(shouldScanProject).each { proj ->
                     def snykConf = null
                     if (proj.configurations.size() > 0) {
                         if (onlyConf != null) {

--- a/test/fixtures/api-configuration/build.gradle
+++ b/test/fixtures/api-configuration/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'java-library'
 
+repositories {
+  mavenCentral()
+}
+
 dependencies {
   api 'commons-httpclient:commons-httpclient:3.1'
 }

--- a/test/fixtures/multi-project-some-unscannable/settings.gradle
+++ b/test/fixtures/multi-project-some-unscannable/settings.gradle
@@ -1,0 +1,6 @@
+rootProject.name = 'root-proj'
+
+include 'subproj'
+include 'subproj-fail'
+
+

--- a/test/fixtures/multi-project-some-unscannable/subproj-fail/build.gradle
+++ b/test/fixtures/multi-project-some-unscannable/subproj-fail/build.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'private.inaccessible:dependency:42.1337'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}

--- a/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
+++ b/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
@@ -1,0 +1,49 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'com.google.guava:guava:18.0'
+  compile 'batik:batik-dom:1.6'
+  compile 'commons-discovery:commons-discovery:0.2'
+  compileOnly 'axis:axis:1.3'
+  compile 'com.android.tools.build:builder:2.3.0'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+// To specify a license in the pom:
+install {
+  repositories.mavenInstaller {
+    pom.project {
+      licenses {
+        license {
+          name 'The Apache Software License, Version 2.0'
+          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          distribution 'repo'
+        }
+      }
+    }
+  }
+}

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -65,7 +65,7 @@ test('multi-project: only sub-project has deps and they are returned', async (t)
     options);
   t.match(result.package.name, '/subproj',
     'sub project name is included in the root pkg name');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj', 'subproj']);
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
 
   t.equal(result.package
     .dependencies!['com.android.tools.build:builder']
@@ -82,7 +82,7 @@ test('multi-project: only sub-project has deps, none returned for main', async (
     path.join(fixtureDir('multi-project'), 'build.gradle'));
   t.match(result.package.name, '.',
     'returned project name is not sub-project');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj', 'subproj']);
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
   t.notOk(result.package.dependencies);
 });
 
@@ -91,7 +91,7 @@ test('multi-project: using gradle via wrapper', async (t) => {
     path.join(fixtureDir('multi-project gradle wrapper'), 'build.gradle'));
   t.match(result.package.name, '.',
     'returned project name is not sub-project');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj', 'subproj']);
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
   t.notOk(result.package.dependencies);
 });
 
@@ -110,7 +110,7 @@ test('multi-project: only sub-project has deps and they are returned space needs
     path.join(fixtureDir('multi-project'), 'build.gradle'),
     options);
 
-    t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj', 'subproj']);
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
 
   t.match(result.package.name, '/subproj',
     'sub project name is included in the root pkg name');
@@ -152,6 +152,42 @@ test('multi-project: deps for both projects are returned with multiDepRoots flag
       // t.match(p.targetFile, 'subproj' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
     }
   }
+});
+
+test('single-project: array of one is returned with multiDepRoots flag', async (t) => {
+  const result = await inspect('.',
+    path.join(fixtureDir('api-configuration'), 'build.gradle'), {multiDepRoots: true});
+  t.equal(result.depRoots.length, 1);
+  t.equal(result.depRoots[0].depTree.name, '.');
+  t.ok(result.depRoots[0].depTree.dependencies!['commons-httpclient:commons-httpclient']);
+});
+
+test('multi-project-some-unscannable: multiDepRoots fails', async (t) => {
+  t.rejects(inspect('.',
+    path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'), {multiDepRoots: true}));
+});
+
+test('multi-project-some-unscannable: gradle-sub-project for a good subproject works', async (t) => {
+  const options = {
+    'gradle-sub-project': 'subproj ',
+  };
+  const result = await inspect('.',
+    path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'),
+    options);
+
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+
+  t.match(result.package.name, '/subproj',
+    'sub project name is included in the root pkg name');
+
+  t.equal(result.package
+    .dependencies!['com.android.tools.build:builder']
+    .dependencies!['com.android.tools:sdklib']
+    .dependencies!['com.android.tools:repository']
+    .dependencies!['com.android.tools:common']
+    .dependencies!['com.android.tools:annotations'].version,
+  '25.3.0',
+  'correct version found');
 });
 
 test('multiDepRoots incompatible with gradle-sub-project', (t) => {
@@ -211,7 +247,7 @@ test('multi-project-dependency-cycle: scanning the main project works fine', asy
     path.join(fixtureDir('multi-project-dependency-cycle'), 'build.gradle'),
     {});
   t.equal(result.package.name, '.', 'root project name is "."');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj', 'subproj']);
+  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
 
   t.equal(result.package
     .dependencies!['com.github.jitpack:subproj']


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Before, init.gradle script always scanned all subprojects. This means if one of the subprojects fails for some reason, all of them do.

Now, if it only needs to scan one project, it will scan one.

