### PR TITLE
fix: reinstate advertising all-sub-projects when only scanning one

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -64,7 +64,7 @@ export interface PluginMetadata {
   meta?: {
     // If we don't return the results for all dependency roots (subprojects),
     // still record their names to warn the user about them not being scanned
-    allDepRootNames?: string[];
+    allSubProjectNames?: string[];
   };
 }
 
@@ -120,9 +120,9 @@ export async function inspect(root, targetFile, options?: SingleRootInspectOptio
     };
   }
   const depTreeAndDepRootNames = await getAllDepsOneProject(root, targetFile, options, subProject);
-  if (depTreeAndDepRootNames.allDepRootNames) {
+  if (depTreeAndDepRootNames.allSubProjectNames) {
     plugin.meta = plugin.meta || {};
-    plugin.meta.allDepRootNames = depTreeAndDepRootNames.allDepRootNames;
+    plugin.meta.allSubProjectNames = depTreeAndDepRootNames.allSubProjectNames;
   }
   return {
     plugin,
@@ -142,6 +142,7 @@ function targetFileFilteredForCompatibility(targetFile: string): string | undefi
 interface JsonDepsScriptResult {
   defaultProject: string;
   projects: ProjectsDict;
+  allSubProjectNames: string[];
 }
 
 interface ProjectsDict {
@@ -171,15 +172,15 @@ function extractJsonFromScriptOutput(stdoutText: string): JsonDepsScriptResult {
 }
 
 async function getAllDepsOneProject(root, targetFile, options, subProject):
-    Promise<{depTree: DepTree, allDepRootNames: string[]}> {
+    Promise<{depTree: DepTree, allSubProjectNames: string[]}> {
   const packageName = path.basename(root);
   const allProjectDeps = await getAllDeps(root, targetFile, options);
-  const allDepRootNames = Object.keys(allProjectDeps.projects);
+  const allSubProjectNames = allProjectDeps.allSubProjectNames;
   let depDict = {} as DepDict;
   if (subProject) {
     return {
       depTree: getDepsSubProject(root, subProject, allProjectDeps),
-      allDepRootNames,
+      allSubProjectNames,
     };
   }
 
@@ -194,7 +195,7 @@ async function getAllDepsOneProject(root, targetFile, options, subProject):
       version: '0.0.0',
       packageFormatVersion,
     },
-    allDepRootNames,
+    allSubProjectNames,
   };
 }
 

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -21,6 +21,7 @@ import groovy.json.JsonOutput
 // interface JsonDepsScriptResult {
 //   defaultProject: string;
 //   projects: ProjectsDict;
+//   allSubProjectNames: string[];
 // }
 // interface ProjectsDict {
 //   [project: string]: GradleProjectInfo;
@@ -71,7 +72,11 @@ allprojects { everyProj ->
         doLast { task ->
             def projectsDict = [:]
             def defaultProjectName = task.project.name
-            def result = ['defaultProject': defaultProjectName, 'projects': projectsDict]
+            def result = [
+                'defaultProject': defaultProjectName,
+                'projects': projectsDict,
+                'allSubProjectNames': allprojects.collect { it.name }
+            ]
             if (!snykMergedDepsConfExecuted) {
 
                 def shouldScanProject = {

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -8,7 +8,7 @@ test('multi-project, explicitly targeting a subproject build file', async (t) =>
     path.join(fixtureDir('multi-project'), 'subproj', 'build.gradle'));
   t.equals(result.package.name, '.',
     'root project is "."');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
 
   t.equal(result.package
     .dependencies!['com.android.tools.build:builder']
@@ -26,7 +26,7 @@ test('multi-project, ran from root, targeting subproj', async (t) => {
     'subproj/build.gradle');
   t.equals(result.package.name, 'multi-project',
     'root project is "multi-project"');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
 
   t.equal(result.package
     .dependencies!['com.android.tools.build:builder']
@@ -44,7 +44,7 @@ test('multi-project, ran from a subproject directory', async (t) => {
     'build.gradle');
   t.equals(result.package.name, 'subproj',
     'root project is "subproj"');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
 
   t.equal(result.package
     .dependencies!['com.android.tools.build:builder']
@@ -65,7 +65,7 @@ test('multi-project: only sub-project has deps and they are returned', async (t)
     options);
   t.match(result.package.name, '/subproj',
     'sub project name is included in the root pkg name');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
 
   t.equal(result.package
     .dependencies!['com.android.tools.build:builder']
@@ -82,7 +82,7 @@ test('multi-project: only sub-project has deps, none returned for main', async (
     path.join(fixtureDir('multi-project'), 'build.gradle'));
   t.match(result.package.name, '.',
     'returned project name is not sub-project');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
   t.notOk(result.package.dependencies);
 });
 
@@ -91,7 +91,7 @@ test('multi-project: using gradle via wrapper', async (t) => {
     path.join(fixtureDir('multi-project gradle wrapper'), 'build.gradle'));
   t.match(result.package.name, '.',
     'returned project name is not sub-project');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
   t.notOk(result.package.dependencies);
 });
 
@@ -110,7 +110,7 @@ test('multi-project: only sub-project has deps and they are returned space needs
     path.join(fixtureDir('multi-project'), 'build.gradle'),
     options);
 
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
 
   t.match(result.package.name, '/subproj',
     'sub project name is included in the root pkg name');
@@ -175,7 +175,7 @@ test('multi-project-some-unscannable: gradle-sub-project for a good subproject w
     path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'),
     options);
 
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['subproj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj', 'subproj-fail']);
 
   t.match(result.package.name, '/subproj',
     'sub project name is included in the root pkg name');
@@ -247,7 +247,7 @@ test('multi-project-dependency-cycle: scanning the main project works fine', asy
     path.join(fixtureDir('multi-project-dependency-cycle'), 'build.gradle'),
     {});
   t.equal(result.package.name, '.', 'root project name is "."');
-  t.deepEqual(result.plugin.meta!.allDepRootNames, ['root-proj']);
+  t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
 
   t.equal(result.package
     .dependencies!['com.github.jitpack:subproj']


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The feature to advertise all-sub-projects was de-facto disabled by https://github.com/snyk/snyk-gradle-plugin/pull/67; this change restores the check by returning the list of the projects explicitly.

