### PR TITLE
fix: scan all sub-projects even when not starting from the root

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -134,9 +134,8 @@ allprojects { everyProj ->
                 // when resolving the project A, so that it selects a concrete variant of dependency B.
                 def allConfigurationAttributes = [:] // Map<Attribute<?>, Set<?>>
                 def attributesAsStrings = [:] // Map<String, Set<string>>
-                allprojects.findAll(shouldScanProject).each { proj ->
-                    println('SNYKECHO processing project: ' + proj.name)
-                    proj.configurations.findAll({ it.name != 'snykMergedDepsConf' && matchesAttributeFilter(it) }).each { conf ->
+                rootProject.allprojects.findAll(shouldScanProject).each { proj ->
+                    proj.configurations.findAll({ it.name != 'snykMergedDepsConf' && it.name =~ confNameFilter && matchesAttributeFilter(it) }).each { conf ->
                         def attrs = conf.attributes
                         attrs.keySet().each({ attr ->
                             def value = attrs.getAttribute(attr)
@@ -154,7 +153,8 @@ allprojects { everyProj ->
                 // due to ambiguous resolution of dependency variants
                 println("JSONATTRS " + JsonOutput.toJson(attributesAsStrings))
 
-                allprojects.findAll(shouldScanProject).each { proj ->
+                rootProject.allprojects.findAll(shouldScanProject).each { proj ->
+                    println('SNYKECHO processing project: ' + proj.name)
                     def snykConf = null
                     def mergeableConfs = proj.configurations
                         .findAll({ it.name != 'snykMergedDepsConf' && it.name =~ confNameFilter })


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Before, snyk processed only the "current" project and its children. Now we will process all.
Apart from the obvious convenience, it also helps with resolving the projects via `--configuration-attributes` flag: if a project depends on its sibling project, we need to check the attributes of the sibling projects to correctly build the set of attributes that reliably matches dependency variants.

Also, apply the config name filter when building the attribute set. Should not affect most use cases, but is a logical thing to do.

