### PR TITLE
fix: scan all subprojects when selecting attributes for conifguration

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,6 +26,12 @@ const packageFormatVersion = 'mvn:0.0.1';
 const isWin = /^win/.test(os.platform());
 const quot = isWin ? '"' : '\'';
 
+const cannotResolveVariantMarkers = [
+  'Cannot choose between the following',
+  'Could not select value from candidates',
+  'Unable to find a matching variant of project',
+];
+
 // TODO(kyegupov): the types below will be extracted to a common plugin interface library
 
 export interface BaseInspectOptions {
@@ -360,8 +366,7 @@ message from above, starting with ===== DEBUG INFORMATION START =====.`;
     // There are no automated tests for this yet (setting up Android SDK is quite problematic).
     // See test/manual/README.md
 
-    if (/Cannot choose between the following/.test(error.message)
-      || /Could not select value from candidates/.test(error.message)) {
+    if (cannotResolveVariantMarkers.find((m) => error.message.includes(m))) {
 
         // Extract attribute information via JSONATTRS marker:
         const jsonAttrs = JSON.parse(

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -154,7 +154,7 @@ allprojects { everyProj ->
                 // when resolving the project A, so that it selects a concrete variant of dependency B.
                 def allConfigurationAttributes = [:] // Map<Attribute<?>, Set<?>>
                 def attributesAsStrings = [:] // Map<String, Set<string>>
-                rootProject.allprojects.findAll(shouldScanProject).each { proj ->
+                rootProject.allprojects.each { proj ->
                     proj.configurations.findAll({ it.name != 'snykMergedDepsConf' && it.name =~ confNameFilter && matchesAttributeFilter(it) }).each { conf ->
                         if (!conf.hasProperty('attributes')) {
                            // Gradle before version 3 does not support attributes

--- a/test/fixtures/multi-config-attributes-subproject/build.gradle
+++ b/test/fixtures/multi-config-attributes-subproject/build.gradle
@@ -1,0 +1,102 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+// See https://docs.gradle.org/current/userguide/dependency_management_attribute_based_matching.html
+
+def specificAttr = Attribute.of("specificAttr", String)
+def commonAttr = Attribute.of("specificAttr", String)
+def usageAttr = null
+
+if (project.hasProperty('objects')) {
+  usageAttr = Attribute.of("org.gradle.usage", Usage)
+  // Gradle 4+
+  configurations {
+      apiConf {
+          attributes {
+              attribute(usageAttr, project.objects.named(Usage, "java-api"))
+              attribute(specificAttr, "rootprojValue")
+              attribute(commonAttr, "common")
+          }
+      }
+      runtimeConf {
+          attributes {
+              attribute(usageAttr, project.objects.named(Usage, "java-runtime"))
+              attribute(specificAttr, "rootprojValue")
+              attribute(commonAttr, "common")
+          }
+      }
+    }
+} else {
+ // Gradle 3
+  usageAttr = Attribute.of('usage', String)
+  configurations {
+      apiConf {
+          attributes {
+              attribute(usageAttr, "java-api")
+              attribute(specificAttr, "rootprojValue")
+              attribute(commonAttr, "common")
+          }
+      }
+      runtimeConf {
+          attributes {
+              attribute(usageAttr, "java-runtime")
+              attribute(specificAttr, "rootprojValue")
+              attribute(commonAttr, "common")
+          }
+      }
+  }
+}
+
+dependencies.attributesSchema {
+    attribute(specificAttr)
+    attribute(usageAttr)
+
+    println('SNYKECHO compatchain ' + attribute(specificAttr).compatibilityRules)
+}
+
+
+dependencies {
+  compile 'com.google.guava:guava:18.0'
+  apiConf 'commons-httpclient:commons-httpclient:3.1'
+  runtimeConf 'org.apache.commons:commons-lang3:3.8.1'
+  compile project(':subproj')
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+// To specify a license in the pom:
+install {
+  repositories.mavenInstaller {
+    pom.project {
+      licenses {
+        license {
+          name 'The Apache Software License, Version 2.0'
+          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          distribution 'repo'
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/multi-config-attributes-subproject/settings.gradle
+++ b/test/fixtures/multi-config-attributes-subproject/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'root-proj'
+
+include 'subproj'

--- a/test/fixtures/multi-config-attributes-subproject/subproj/build.gradle
+++ b/test/fixtures/multi-config-attributes-subproject/subproj/build.gradle
@@ -1,0 +1,60 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.github.jitpack'
+
+sourceCompatibility = 1.8 // java 8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+def specificAttr = Attribute.of("specificAttr", String)
+def commonAttr = Attribute.of("specificAttr", String)
+def usageAttr = null
+
+if (project.hasProperty('objects')) {
+  usageAttr = Attribute.of("org.gradle.usage", Usage)
+  // Gradle 4+
+  configurations {
+      apiConf {
+          attributes {
+              attribute(usageAttr, project.objects.named(Usage, "java-api"))
+              attribute(specificAttr, "subproj1Value")
+              attribute(commonAttr, "common")
+          }
+      }
+      runtimeConf {
+          attributes {
+              attribute(usageAttr, project.objects.named(Usage, "java-runtime"))
+              attribute(specificAttr, "subproj1Value")
+              attribute(commonAttr, "common")
+          }
+      }
+    }
+} else {
+ // Gradle 3
+  usageAttr = Attribute.of('usage', String)
+  configurations {
+      apiConf {
+          attributes {
+              attribute(usageAttr, "java-api")
+              attribute(specificAttr, "subproj1Value")
+              attribute(commonAttr, "common")
+          }
+      }
+      runtimeConf {
+          attributes {
+              attribute(usageAttr, "java-runtime")
+              attribute(specificAttr, "subproj2Value")
+              attribute(commonAttr, "common")
+          }
+      }
+  }
+}
+
+dependencies.attributesSchema {
+    attribute(specificAttr)
+    attribute(usageAttr)
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
To make sure the constructed configuration is compatible with all the sub-projects of the project, we should scan all of them to find attributes that match user specification.

We even have a comment explaining why we should have been doing that, but we were only scanning a specified project. This has caused problems for some our customers.

Drive-by: recognise one more variant of Gradle error message related to unresolvable variants when displaying extended error message.

