### PR TITLE
fix: expose all three inspect() overloads in plugin types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,23 +60,25 @@ export interface GradleInspectOptions {
 
 type Options = InspectOptions & GradleInspectOptions;
 
-// TODO: move everything to inspect.ts, and make index.ts just a re-export of `inspect` with a typecheck
+// Overload type definitions, so that when you call inspect() with an `options` literal (e.g. in tests),
+// you will get a result of a specific corresponding type.
 export async function inspect(
   root: string,
   targetFile: string,
-  options?: SingleSubprojectInspectOptions & GradleInspectOptions):
-  Promise<SinglePackageResult>;
+  options?: SingleSubprojectInspectOptions & GradleInspectOptions,
+): Promise<SinglePackageResult>;
 export async function inspect(
   root: string,
   targetFile: string,
-  options: MultiSubprojectInspectOptions & GradleInspectOptions):
-  Promise<MultiProjectResult>;
+  options: MultiSubprojectInspectOptions & GradleInspectOptions,
+): Promise<MultiProjectResult>;
 
+// General implementation. The result type depends on the runtime type of `options`.
 export async function inspect(
-    root: string,
-    targetFile: string,
-    options?: Options,
-    ): Promise<InspectResult> {
+  root: string,
+  targetFile: string,
+  options?: Options,
+): Promise<InspectResult> {
   if (!options) {
     options = {dev: false};
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@snyk/cli-interface": "^1.2.0",
+    "@snyk/cli-interface": "^1.3.1",
     "@types/chalk": "^2.2.0",
     "@types/jest": "^24.0.13",
     "@types/node": "^4.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Updates the plugin Typescript interface (version bump for snyk/cli-interface).
v1.3.1 is the one we want; v1.4.0 didn't work out after all and will be reverted via https://github.com/snyk/snyk-cli-interface/pull/10

Also, some code formatting and comment updates.