### PR TITLE
fix: plain console mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
   - unset JAVA_HOME
+  - export GRADLE_OPTS=-Dorg.gradle.console=verbose
 jobs:
   include:
   - stage: Different Node/Java versions + most recent Gradle version
@@ -25,8 +26,9 @@ jobs:
     # Tested Java versions are usually: 8 (LTS), 11 (LTS), 13 (latest)
     # (see https://www.oracle.com/technetwork/java/java-se-support-roadmap.html)
     # LTS version are also the most popular ones: https://www.baeldung.com/java-in-2019
+
     # We use sdkman to install Java.
-    # AdoptOpenJDK distibution with HotSpot VM is chosen as the most "classic" option.
+    # AdoptOpenJDK distribution with HotSpot VM is chosen as the most "classic" option.
     node_js: 6
     env: GRADLE_VERSION=6.0 JDK=8 Node.js=6
     script:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -498,6 +498,11 @@ function buildArgs(
   // Not `=false` to be compatible with 3.5.x: https://github.com/gradle/gradle/issues/1827
   args.push('-Dorg.gradle.parallel=');
 
+  // Since version 4.3.0+ Gradle uses different console output mechanism. Default mode is 'auto',
+  // if Gradle is attached to a terminal. It means build output will use ANSI control characters
+  // to generate the rich output, therefore JSON cannot be parsed.
+  args.push('-Dorg.gradle.console=plain');
+
   if (!api.isMultiSubProject(options)) {
     args.push('-PonlySubProject=' + (options.subProject || '.'));
   }

--- a/test/functional/gradle-plugin.test.ts
+++ b/test/functional/gradle-plugin.test.ts
@@ -21,6 +21,7 @@ test('check build args with array (new configuration arg)', async (t) => {
     `-Pconfiguration=${quot}confRegex${quot}`,
     '--no-daemon',
     '-Dorg.gradle.parallel=',
+    '-Dorg.gradle.console=plain',
     '-PonlySubProject=.',
     '-I /tmp/init.gradle',
     '--build-file',
@@ -42,6 +43,7 @@ test('check build args with array (legacy configuration arg)', async (t) => {
     '-q',
     '--no-daemon',
     '-Dorg.gradle.parallel=',
+    '-Dorg.gradle.console=plain',
     '-PonlySubProject=.',
     '-I /tmp/init.gradle',
     '--build-file',
@@ -65,6 +67,7 @@ test('check build args with scan all subprojects', async (t) => {
     '-q',
     '--no-daemon',
     '-Dorg.gradle.parallel=',
+    '-Dorg.gradle.console=plain',
     '-I /tmp/init.gradle',
     '--build-file',
     'build.gradle',
@@ -101,4 +104,22 @@ test('extractJsonFromScriptOutput throws on multiple JSONDEPS', async (t) => {
     t.match(e.message, 'More than one line with "JSONDEPS " prefix was returned', 'expected error message');
     t.match(e.message, output, 'error message contains output');
   }
+});
+
+test('check build args (plain console output)', async (t) => {
+  const result = testableMethods.buildArgs(
+    '.',
+    null,
+    '/tmp/init.gradle',
+    {},
+  );
+  t.deepEqual(result, [
+    'snykResolvedDepsJson',
+    '-q',
+    '--no-daemon',
+    '-Dorg.gradle.parallel=',
+     '-Dorg.gradle.console=plain',
+    '-PonlySubProject=.',
+    '-I /tmp/init.gradle',
+  ]);
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR forces `plain` console mode when executing Gradle commands. If it's not set, then build output contains control ANSI characters and generated JSON cannot be parsed.

This PR was triggered by failed issues in teamcity plugin.

#### Where should the reviewer start?
Compare 2 Travis builds:
- failed build after console mode is manually set from outside: https://travis-ci.org/snyk/snyk-gradle-plugin/builds/633516869
- passed build after console mode is set for each Gradle command executing https://travis-ci.org/snyk/snyk-gradle-plugin/builds/633540774
