### PR TITLE
fix: remove unused dep that was bringing vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@snyk/cli-interface": "2.3.0",
     "@types/debug": "^4.1.4",
     "chalk": "^2.4.2",
-    "clone-deep": "^0.3.0",
     "debug": "^4.1.1",
     "tmp": "0.0.33",
     "tslib": "^1.9.3"


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Remove `clone-deep` cos it's not used since https://github.com/snyk/snyk-gradle-plugin/commit/04cf66ddfa4cd484e609836ee5f10f2ae95daefb