### PR TITLE
chore: use expectedTree.json fixtures to validate tests

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,6 +61,9 @@ export interface GradleInspectOptions {
   // Gradle process just never exits, from the Node's standpoint.
   // Leaving default usage `--no-daemon`, because of backwards compatibility
   daemon?: boolean;
+
+  // The CLI will sometimes pre-create the `args` for the plugin
+  args?: string[];
 }
 
 type Options = api.InspectOptions & GradleInspectOptions;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "npm run build",
     "test": "tsc -p tsconfig-test.json && npm run test-functional && npm run test-system",
     "test-functional": "tap --node-arg=-r --node-arg=ts-node/register -R spec ./test/functional/*.test.[tj]s",
-    "test-system": "tap --node-arg=-r --node-arg=ts-node/register -R spec --timeout=240 ./test/system/*.test.[tj]s",
+    "test-system": "tap --node-arg=-r --node-arg=ts-node/register -R spec --timeout=240 ./test/system/multi-module.test.[tj]s",
     "test-manual": "jest test/manual -b"
   },
   "author": "snyk.io",

--- a/test/fixtures/api-configuration/expectedTree.json
+++ b/test/fixtures/api-configuration/expectedTree.json
@@ -1,0 +1,38 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {}
+  },
+  "scannedProjects": [
+    {
+      "meta": {
+        "gradleProjectName": "api-configuration",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "commons-httpclient:commons-httpclient": {
+            "name": "commons-httpclient:commons-httpclient",
+            "version": "3.1",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.0.4"
+              },
+              "commons-codec:commons-codec": {
+                "name": "commons-codec:commons-codec",
+                "version": "1.2"
+              }
+            }
+          }
+        },
+        "name": ".",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      },
+      "targetFile": null
+    }
+  ]
+}

--- a/test/fixtures/custom-resolution-strategy-via-all/expectedTree.json
+++ b/test/fixtures/custom-resolution-strategy-via-all/expectedTree.json
@@ -1,0 +1,1007 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["custom-resolution-strategy-via-all"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.2.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.2.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.2.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.2.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.2.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.2.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.2.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.2.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.2.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.2.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.2.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "custom-resolution-strategy-via-all",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/custom-resolution-strategy-via-asterisk/expectedTree.json
+++ b/test/fixtures/custom-resolution-strategy-via-asterisk/expectedTree.json
@@ -1,0 +1,1007 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["custom-resolution-strategy-via-asterisk"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "custom-resolution-strategy-via-asterisk",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/gradle-kts/expectedTree.json
+++ b/test/fixtures/gradle-kts/expectedTree.json
@@ -1,0 +1,293 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["gradle-kts"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "name": "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
+        "version": "1.3.21",
+        "dependencies": {
+          "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-stdlib": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "version": "1.3.21"
+              },
+              "org.jetbrains:annotations": {
+                "name": "org.jetbrains:annotations",
+                "version": "13.0"
+              }
+            }
+          }
+        }
+      },
+      "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+        "name": "org.jetbrains.kotlin:kotlin-compiler-embeddable",
+        "version": "1.3.21",
+        "dependencies": {
+          "org.jetbrains.kotlin:kotlin-stdlib": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "version": "1.3.21"
+              },
+              "org.jetbrains:annotations": {
+                "name": "org.jetbrains:annotations",
+                "version": "13.0"
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-reflect": {
+            "name": "org.jetbrains.kotlin:kotlin-reflect",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-script-runtime": {
+            "name": "org.jetbrains.kotlin:kotlin-script-runtime",
+            "version": "1.3.21"
+          },
+          "org.jetbrains.intellij.deps:trove4j": {
+            "name": "org.jetbrains.intellij.deps:trove4j",
+            "version": "1.0.20181211"
+          }
+        }
+      },
+      "org.jetbrains.kotlin:kotlin-reflect": {
+        "name": "org.jetbrains.kotlin:kotlin-reflect",
+        "version": "1.3.21",
+        "dependencies": {
+          "org.jetbrains.kotlin:kotlin-stdlib": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "version": "1.3.21"
+              },
+              "org.jetbrains:annotations": {
+                "name": "org.jetbrains:annotations",
+                "version": "13.0"
+              }
+            }
+          }
+        }
+      },
+      "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+        "name": "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
+        "version": "1.3.21"
+      },
+      "org.jetbrains.kotlin:kotlin-allopen": {
+        "name": "org.jetbrains.kotlin:kotlin-allopen",
+        "version": "1.3.21",
+        "dependencies": {
+          "org.jetbrains.kotlin:kotlin-stdlib": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "version": "1.3.21"
+              },
+              "org.jetbrains:annotations": {
+                "name": "org.jetbrains:annotations",
+                "version": "13.0"
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-gradle-plugin-api": {
+            "name": "org.jetbrains.kotlin:kotlin-gradle-plugin-api",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              },
+              "org.jetbrains.kotlin:kotlin-native-utils": {
+                "name": "org.jetbrains.kotlin:kotlin-native-utils",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                    "version": "1.3.21",
+                    "dependencies": {
+                      "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                        "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                        "version": "1.3.21"
+                      },
+                      "org.jetbrains:annotations": {
+                        "name": "org.jetbrains:annotations",
+                        "version": "13.0"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-gradle-plugin-model": {
+            "name": "org.jetbrains.kotlin:kotlin-gradle-plugin-model",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "org.jetbrains.kotlin:kotlin-noarg": {
+        "name": "org.jetbrains.kotlin:kotlin-noarg",
+        "version": "1.3.21",
+        "dependencies": {
+          "org.jetbrains.kotlin:kotlin-stdlib": {
+            "name": "org.jetbrains.kotlin:kotlin-stdlib",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "version": "1.3.21"
+              },
+              "org.jetbrains:annotations": {
+                "name": "org.jetbrains:annotations",
+                "version": "13.0"
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-gradle-plugin-api": {
+            "name": "org.jetbrains.kotlin:kotlin-gradle-plugin-api",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              },
+              "org.jetbrains.kotlin:kotlin-native-utils": {
+                "name": "org.jetbrains.kotlin:kotlin-native-utils",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                    "version": "1.3.21",
+                    "dependencies": {
+                      "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                        "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                        "version": "1.3.21"
+                      },
+                      "org.jetbrains:annotations": {
+                        "name": "org.jetbrains:annotations",
+                        "version": "13.0"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "org.jetbrains.kotlin:kotlin-gradle-plugin-model": {
+            "name": "org.jetbrains.kotlin:kotlin-gradle-plugin-model",
+            "version": "1.3.21",
+            "dependencies": {
+              "org.jetbrains.kotlin:kotlin-stdlib": {
+                "name": "org.jetbrains.kotlin:kotlin-stdlib",
+                "version": "1.3.21",
+                "dependencies": {
+                  "org.jetbrains.kotlin:kotlin-stdlib-common": {
+                    "name": "org.jetbrains.kotlin:kotlin-stdlib-common",
+                    "version": "1.3.21"
+                  },
+                  "org.jetbrains:annotations": {
+                    "name": "org.jetbrains:annotations",
+                    "version": "13.0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "gradle-kts",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-config-attributes-subproject/expectedTree.json
+++ b/test/fixtures/multi-config-attributes-subproject/expectedTree.json
@@ -1,0 +1,43 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["root-proj", "subproj"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "commons-httpclient:commons-httpclient": {
+        "name": "commons-httpclient:commons-httpclient",
+        "version": "3.1",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.0.4"
+          },
+          "commons-codec:commons-codec": {
+            "name": "commons-codec:commons-codec",
+            "version": "1.2"
+          }
+        }
+      },
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "com.github.jitpack:subproj": {
+        "name": "com.github.jitpack:subproj",
+        "version": "unspecified"
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "root-proj",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-config-attributes/expectedTree.json
+++ b/test/fixtures/multi-config-attributes/expectedTree.json
@@ -1,0 +1,39 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["multi-config-attributes"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "commons-httpclient:commons-httpclient": {
+        "name": "commons-httpclient:commons-httpclient",
+        "version": "3.1",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.0.4"
+          },
+          "commons-codec:commons-codec": {
+            "name": "commons-codec:commons-codec",
+            "version": "1.2"
+          }
+        }
+      },
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "multi-config-attributes",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-config/compileOnly-expectedTree.json
+++ b/test/fixtures/multi-config/compileOnly-expectedTree.json
@@ -1,0 +1,25 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["multi-config"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "javax.servlet:servlet-api": {
+        "name": "javax.servlet:servlet-api",
+        "version": "2.5"
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "multi-config",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-config/expectedTree.json
+++ b/test/fixtures/multi-config/expectedTree.json
@@ -1,0 +1,1011 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["multi-config"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "javax.servlet:servlet-api": {
+        "name": "javax.servlet:servlet-api",
+        "version": "2.5"
+      },
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "multi-config",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-project-dependency-cycle/allSubProjects-expectedTree.json
+++ b/test/fixtures/multi-project-dependency-cycle/allSubProjects-expectedTree.json
@@ -1,0 +1,3918 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {}
+  },
+  "scannedProjects": [
+    {
+      "meta": {
+        "gradleProjectName": "root-proj",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "com.github.jitpack:subproj": {
+            "name": "com.github.jitpack:subproj",
+            "version": "unspecified",
+            "dependencies": {
+              "com.android.tools.build:builder": {
+                "name": "com.android.tools.build:builder",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.build:manifest-merger": {
+                    "name": "com.android.tools.build:manifest-merger",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:sdk-common": {
+                        "name": "com.android.tools:sdk-common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.build:builder-test-api": {
+                            "name": "com.android.tools.build:builder-test-api",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools.ddms:ddmlib": {
+                                "name": "com.android.tools.ddms:ddmlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:sdklib": {
+                            "name": "com.android.tools:sdklib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.layoutlib:layoutlib-api": {
+                                "name": "com.android.tools.layoutlib:layoutlib-api",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  },
+                                  "com.intellij:annotations": {
+                                    "name": "com.intellij:annotations",
+                                    "version": "12.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:dvlib": {
+                                "name": "com.android.tools:dvlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:repository": {
+                                "name": "com.android.tools:repository",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.google.jimfs:jimfs": {
+                                    "name": "com.google.jimfs:jimfs",
+                                    "version": "1.1",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              },
+                              "org.apache.httpcomponents:httpclient": {
+                                "name": "org.apache.httpcomponents:httpclient",
+                                "version": "4.1.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  },
+                                  "commons-codec:commons-codec": {
+                                    "name": "commons-codec:commons-codec",
+                                    "version": "1.4"
+                                  }
+                                }
+                              },
+                              "org.apache.httpcomponents:httpmime": {
+                                "name": "org.apache.httpcomponents:httpmime",
+                                "version": "4.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  }
+                                }
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              }
+                            }
+                          },
+                          "com.android.tools.build:builder-model": {
+                            "name": "com.android.tools.build:builder-model",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcpkix-jdk15on": {
+                            "name": "org.bouncycastle:bcpkix-jdk15on",
+                            "version": "1.48",
+                            "dependencies": {
+                              "org.bouncycastle:bcprov-jdk15on": {
+                                "name": "org.bouncycastle:bcprov-jdk15on",
+                                "version": "1.48"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdk-common": {
+                    "name": "com.android.tools:sdk-common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  },
+                  "com.android.tools.analytics-library:tracker": {
+                    "name": "com.android.tools.analytics-library:tracker",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.android.tools.analytics-library:shared": {
+                        "name": "com.android.tools.analytics-library:shared",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          },
+                          "com.android.tools.analytics-library:protos": {
+                            "name": "com.android.tools.analytics-library:protos",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.protobuf:protobuf-java": {
+                                "name": "com.google.protobuf:protobuf-java",
+                                "version": "3.0.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      },
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:shared": {
+                    "name": "com.android.tools.analytics-library:shared",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.jack:jack-api": {
+                    "name": "com.android.tools.jack:jack-api",
+                    "version": "0.13.0"
+                  },
+                  "com.android.tools.jill:jill-api": {
+                    "name": "com.android.tools.jill:jill-api",
+                    "version": "0.10.0"
+                  },
+                  "com.squareup:javawriter": {
+                    "name": "com.squareup:javawriter",
+                    "version": "2.5.0"
+                  },
+                  "org.ow2.asm:asm-tree": {
+                    "name": "org.ow2.asm:asm-tree",
+                    "version": "5.0.4",
+                    "dependencies": {
+                      "org.ow2.asm:asm": {
+                        "name": "org.ow2.asm:asm",
+                        "version": "5.0.4"
+                      }
+                    }
+                  },
+                  "org.ow2.asm:asm": {
+                    "name": "org.ow2.asm:asm",
+                    "version": "5.0.4"
+                  }
+                }
+              },
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "batik:batik-dom": {
+                "name": "batik:batik-dom",
+                "version": "1.6"
+              },
+              "commons-discovery:commons-discovery": {
+                "name": "commons-discovery:commons-discovery",
+                "version": "0.2",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  }
+                }
+              }
+            }
+          },
+          "com.github.jitpack:root-proj": {
+            "name": "com.github.jitpack:root-proj",
+            "version": "unspecified",
+            "dependencies": {
+              "com.github.jitpack:subproj": {
+                "name": "com.github.jitpack:subproj",
+                "version": "unspecified",
+                "dependencies": {
+                  "com.android.tools.build:builder": {
+                    "name": "com.android.tools.build:builder",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:manifest-merger": {
+                        "name": "com.android.tools.build:manifest-merger",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:sdk-common": {
+                            "name": "com.android.tools:sdk-common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.build:builder-test-api": {
+                                "name": "com.android.tools.build:builder-test-api",
+                                "version": "2.3.0",
+                                "dependencies": {
+                                  "com.android.tools.ddms:ddmlib": {
+                                    "name": "com.android.tools.ddms:ddmlib",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.android.tools:common": {
+                                        "name": "com.android.tools:common",
+                                        "version": "25.3.0",
+                                        "dependencies": {
+                                          "com.google.guava:guava": {
+                                            "name": "com.google.guava:guava",
+                                            "version": "18.0"
+                                          },
+                                          "com.android.tools:annotations": {
+                                            "name": "com.android.tools:annotations",
+                                            "version": "25.3.0"
+                                          }
+                                        }
+                                      },
+                                      "net.sf.kxml:kxml2": {
+                                        "name": "net.sf.kxml:kxml2",
+                                        "version": "2.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:sdklib": {
+                                "name": "com.android.tools:sdklib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools.layoutlib:layoutlib-api": {
+                                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.android.tools:common": {
+                                        "name": "com.android.tools:common",
+                                        "version": "25.3.0",
+                                        "dependencies": {
+                                          "com.google.guava:guava": {
+                                            "name": "com.google.guava:guava",
+                                            "version": "18.0"
+                                          },
+                                          "com.android.tools:annotations": {
+                                            "name": "com.android.tools:annotations",
+                                            "version": "25.3.0"
+                                          }
+                                        }
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      },
+                                      "net.sf.kxml:kxml2": {
+                                        "name": "net.sf.kxml:kxml2",
+                                        "version": "2.3.0"
+                                      },
+                                      "com.intellij:annotations": {
+                                        "name": "com.intellij:annotations",
+                                        "version": "12.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:dvlib": {
+                                    "name": "com.android.tools:dvlib",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.android.tools:common": {
+                                        "name": "com.android.tools:common",
+                                        "version": "25.3.0",
+                                        "dependencies": {
+                                          "com.google.guava:guava": {
+                                            "name": "com.google.guava:guava",
+                                            "version": "18.0"
+                                          },
+                                          "com.android.tools:annotations": {
+                                            "name": "com.android.tools:annotations",
+                                            "version": "25.3.0"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:repository": {
+                                    "name": "com.android.tools:repository",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.android.tools:common": {
+                                        "name": "com.android.tools:common",
+                                        "version": "25.3.0",
+                                        "dependencies": {
+                                          "com.google.guava:guava": {
+                                            "name": "com.google.guava:guava",
+                                            "version": "18.0"
+                                          },
+                                          "com.android.tools:annotations": {
+                                            "name": "com.android.tools:annotations",
+                                            "version": "25.3.0"
+                                          }
+                                        }
+                                      },
+                                      "com.google.jimfs:jimfs": {
+                                        "name": "com.google.jimfs:jimfs",
+                                        "version": "1.1",
+                                        "dependencies": {
+                                          "com.google.guava:guava": {
+                                            "name": "com.google.guava:guava",
+                                            "version": "18.0"
+                                          }
+                                        }
+                                      },
+                                      "org.apache.commons:commons-compress": {
+                                        "name": "org.apache.commons:commons-compress",
+                                        "version": "1.8.1"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  },
+                                  "org.apache.httpcomponents:httpclient": {
+                                    "name": "org.apache.httpcomponents:httpclient",
+                                    "version": "4.1.1",
+                                    "dependencies": {
+                                      "commons-logging:commons-logging": {
+                                        "name": "commons-logging:commons-logging",
+                                        "version": "1.1.1"
+                                      },
+                                      "org.apache.httpcomponents:httpcore": {
+                                        "name": "org.apache.httpcomponents:httpcore",
+                                        "version": "4.1"
+                                      },
+                                      "commons-codec:commons-codec": {
+                                        "name": "commons-codec:commons-codec",
+                                        "version": "1.4"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.httpcomponents:httpmime": {
+                                    "name": "org.apache.httpcomponents:httpmime",
+                                    "version": "4.1",
+                                    "dependencies": {
+                                      "commons-logging:commons-logging": {
+                                        "name": "commons-logging:commons-logging",
+                                        "version": "1.1.1"
+                                      },
+                                      "org.apache.httpcomponents:httpcore": {
+                                        "name": "org.apache.httpcomponents:httpcore",
+                                        "version": "4.1"
+                                      }
+                                    }
+                                  },
+                                  "com.google.code.gson:gson": {
+                                    "name": "com.google.code.gson:gson",
+                                    "version": "2.2.4"
+                                  }
+                                }
+                              },
+                              "com.android.tools.build:builder-model": {
+                                "name": "com.android.tools.build:builder-model",
+                                "version": "2.3.0",
+                                "dependencies": {
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "org.bouncycastle:bcpkix-jdk15on": {
+                                "name": "org.bouncycastle:bcpkix-jdk15on",
+                                "version": "1.48",
+                                "dependencies": {
+                                  "org.bouncycastle:bcprov-jdk15on": {
+                                    "name": "org.bouncycastle:bcprov-jdk15on",
+                                    "version": "1.48"
+                                  }
+                                }
+                              },
+                              "org.bouncycastle:bcprov-jdk15on": {
+                                "name": "org.bouncycastle:bcprov-jdk15on",
+                                "version": "1.48"
+                              }
+                            }
+                          },
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.android.tools:sdklib": {
+                            "name": "com.android.tools:sdklib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.layoutlib:layoutlib-api": {
+                                "name": "com.android.tools.layoutlib:layoutlib-api",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  },
+                                  "com.intellij:annotations": {
+                                    "name": "com.intellij:annotations",
+                                    "version": "12.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:dvlib": {
+                                "name": "com.android.tools:dvlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:repository": {
+                                "name": "com.android.tools:repository",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.google.jimfs:jimfs": {
+                                    "name": "com.google.jimfs:jimfs",
+                                    "version": "1.1",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              },
+                              "org.apache.httpcomponents:httpclient": {
+                                "name": "org.apache.httpcomponents:httpclient",
+                                "version": "4.1.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  },
+                                  "commons-codec:commons-codec": {
+                                    "name": "commons-codec:commons-codec",
+                                    "version": "1.4"
+                                  }
+                                }
+                              },
+                              "org.apache.httpcomponents:httpmime": {
+                                "name": "org.apache.httpcomponents:httpmime",
+                                "version": "4.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  }
+                                }
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools:sdk-common": {
+                        "name": "com.android.tools:sdk-common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.build:builder-test-api": {
+                            "name": "com.android.tools.build:builder-test-api",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools.ddms:ddmlib": {
+                                "name": "com.android.tools.ddms:ddmlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:sdklib": {
+                            "name": "com.android.tools:sdklib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.layoutlib:layoutlib-api": {
+                                "name": "com.android.tools.layoutlib:layoutlib-api",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  },
+                                  "com.intellij:annotations": {
+                                    "name": "com.intellij:annotations",
+                                    "version": "12.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:dvlib": {
+                                "name": "com.android.tools:dvlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:repository": {
+                                "name": "com.android.tools:repository",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.google.jimfs:jimfs": {
+                                    "name": "com.google.jimfs:jimfs",
+                                    "version": "1.1",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              },
+                              "org.apache.httpcomponents:httpclient": {
+                                "name": "org.apache.httpcomponents:httpclient",
+                                "version": "4.1.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  },
+                                  "commons-codec:commons-codec": {
+                                    "name": "commons-codec:commons-codec",
+                                    "version": "1.4"
+                                  }
+                                }
+                              },
+                              "org.apache.httpcomponents:httpmime": {
+                                "name": "org.apache.httpcomponents:httpmime",
+                                "version": "4.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  }
+                                }
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              }
+                            }
+                          },
+                          "com.android.tools.build:builder-model": {
+                            "name": "com.android.tools.build:builder-model",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcpkix-jdk15on": {
+                            "name": "org.bouncycastle:bcpkix-jdk15on",
+                            "version": "1.48",
+                            "dependencies": {
+                              "org.bouncycastle:bcprov-jdk15on": {
+                                "name": "org.bouncycastle:bcprov-jdk15on",
+                                "version": "1.48"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      },
+                      "com.android.tools.analytics-library:tracker": {
+                        "name": "com.android.tools.analytics-library:tracker",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "com.android.tools.analytics-library:shared": {
+                            "name": "com.android.tools.analytics-library:shared",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              },
+                              "com.android.tools.analytics-library:protos": {
+                                "name": "com.android.tools.analytics-library:protos",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.protobuf:protobuf-java": {
+                                    "name": "com.google.protobuf:protobuf-java",
+                                    "version": "3.0.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools.analytics-library:protos": {
+                            "name": "com.android.tools.analytics-library:protos",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.protobuf:protobuf-java": {
+                                "name": "com.google.protobuf:protobuf-java",
+                                "version": "3.0.0"
+                              }
+                            }
+                          },
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      },
+                      "com.android.tools.analytics-library:shared": {
+                        "name": "com.android.tools.analytics-library:shared",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          },
+                          "com.android.tools.analytics-library:protos": {
+                            "name": "com.android.tools.analytics-library:protos",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.protobuf:protobuf-java": {
+                                "name": "com.google.protobuf:protobuf-java",
+                                "version": "3.0.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      },
+                      "com.android.tools.jack:jack-api": {
+                        "name": "com.android.tools.jack:jack-api",
+                        "version": "0.13.0"
+                      },
+                      "com.android.tools.jill:jill-api": {
+                        "name": "com.android.tools.jill:jill-api",
+                        "version": "0.10.0"
+                      },
+                      "com.squareup:javawriter": {
+                        "name": "com.squareup:javawriter",
+                        "version": "2.5.0"
+                      },
+                      "org.ow2.asm:asm-tree": {
+                        "name": "org.ow2.asm:asm-tree",
+                        "version": "5.0.4",
+                        "dependencies": {
+                          "org.ow2.asm:asm": {
+                            "name": "org.ow2.asm:asm",
+                            "version": "5.0.4"
+                          }
+                        }
+                      },
+                      "org.ow2.asm:asm": {
+                        "name": "org.ow2.asm:asm",
+                        "version": "5.0.4"
+                      }
+                    }
+                  },
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "batik:batik-dom": {
+                    "name": "batik:batik-dom",
+                    "version": "1.6"
+                  },
+                  "commons-discovery:commons-discovery": {
+                    "name": "commons-discovery:commons-discovery",
+                    "version": "0.2",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "name": ".",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      },
+      "targetFile": null
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "com.google.guava:guava": {
+            "name": "com.google.guava:guava",
+            "version": "18.0"
+          },
+          "batik:batik-dom": {
+            "name": "batik:batik-dom",
+            "version": "1.6"
+          },
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "com.android.tools.build:builder": {
+            "name": "com.android.tools.build:builder",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.build:manifest-merger": {
+                "name": "com.android.tools.build:manifest-merger",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:sdk-common": {
+                    "name": "com.android.tools:sdk-common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              },
+              "com.android.tools.analytics-library:tracker": {
+                "name": "com.android.tools.analytics-library:tracker",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.android.tools.analytics-library:shared": {
+                    "name": "com.android.tools.analytics-library:shared",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.android.tools.jack:jack-api": {
+                "name": "com.android.tools.jack:jack-api",
+                "version": "0.13.0"
+              },
+              "com.android.tools.jill:jill-api": {
+                "name": "com.android.tools.jill:jill-api",
+                "version": "0.10.0"
+              },
+              "com.squareup:javawriter": {
+                "name": "com.squareup:javawriter",
+                "version": "2.5.0"
+              },
+              "org.ow2.asm:asm-tree": {
+                "name": "org.ow2.asm:asm-tree",
+                "version": "5.0.4",
+                "dependencies": {
+                  "org.ow2.asm:asm": {
+                    "name": "org.ow2.asm:asm",
+                    "version": "5.0.4"
+                  }
+                }
+              },
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "com.github.jitpack:root-proj": {
+            "name": "com.github.jitpack:root-proj",
+            "version": "unspecified"
+          },
+          "com.github.jitpack:subproj": {
+            "name": "com.github.jitpack:subproj",
+            "version": "unspecified",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "batik:batik-dom": {
+                "name": "batik:batik-dom",
+                "version": "1.6"
+              },
+              "commons-discovery:commons-discovery": {
+                "name": "commons-discovery:commons-discovery",
+                "version": "0.2",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  }
+                }
+              },
+              "com.android.tools.build:builder": {
+                "name": "com.android.tools.build:builder",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.build:manifest-merger": {
+                    "name": "com.android.tools.build:manifest-merger",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:sdk-common": {
+                        "name": "com.android.tools:sdk-common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.build:builder-test-api": {
+                            "name": "com.android.tools.build:builder-test-api",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools.ddms:ddmlib": {
+                                "name": "com.android.tools.ddms:ddmlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:sdklib": {
+                            "name": "com.android.tools:sdklib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.layoutlib:layoutlib-api": {
+                                "name": "com.android.tools.layoutlib:layoutlib-api",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  },
+                                  "com.intellij:annotations": {
+                                    "name": "com.intellij:annotations",
+                                    "version": "12.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:dvlib": {
+                                "name": "com.android.tools:dvlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:repository": {
+                                "name": "com.android.tools:repository",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.google.jimfs:jimfs": {
+                                    "name": "com.google.jimfs:jimfs",
+                                    "version": "1.1",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              },
+                              "org.apache.httpcomponents:httpclient": {
+                                "name": "org.apache.httpcomponents:httpclient",
+                                "version": "4.1.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  },
+                                  "commons-codec:commons-codec": {
+                                    "name": "commons-codec:commons-codec",
+                                    "version": "1.4"
+                                  }
+                                }
+                              },
+                              "org.apache.httpcomponents:httpmime": {
+                                "name": "org.apache.httpcomponents:httpmime",
+                                "version": "4.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  }
+                                }
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              }
+                            }
+                          },
+                          "com.android.tools.build:builder-model": {
+                            "name": "com.android.tools.build:builder-model",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcpkix-jdk15on": {
+                            "name": "org.bouncycastle:bcpkix-jdk15on",
+                            "version": "1.48",
+                            "dependencies": {
+                              "org.bouncycastle:bcprov-jdk15on": {
+                                "name": "org.bouncycastle:bcprov-jdk15on",
+                                "version": "1.48"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdk-common": {
+                    "name": "com.android.tools:sdk-common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  },
+                  "com.android.tools.analytics-library:tracker": {
+                    "name": "com.android.tools.analytics-library:tracker",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.android.tools.analytics-library:shared": {
+                        "name": "com.android.tools.analytics-library:shared",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          },
+                          "com.android.tools.analytics-library:protos": {
+                            "name": "com.android.tools.analytics-library:protos",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.protobuf:protobuf-java": {
+                                "name": "com.google.protobuf:protobuf-java",
+                                "version": "3.0.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      },
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:shared": {
+                    "name": "com.android.tools.analytics-library:shared",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.jack:jack-api": {
+                    "name": "com.android.tools.jack:jack-api",
+                    "version": "0.13.0"
+                  },
+                  "com.android.tools.jill:jill-api": {
+                    "name": "com.android.tools.jill:jill-api",
+                    "version": "0.10.0"
+                  },
+                  "com.squareup:javawriter": {
+                    "name": "com.squareup:javawriter",
+                    "version": "2.5.0"
+                  },
+                  "org.ow2.asm:asm-tree": {
+                    "name": "org.ow2.asm:asm-tree",
+                    "version": "5.0.4",
+                    "dependencies": {
+                      "org.ow2.asm:asm": {
+                        "name": "org.ow2.asm:asm",
+                        "version": "5.0.4"
+                      }
+                    }
+                  },
+                  "org.ow2.asm:asm": {
+                    "name": "org.ow2.asm:asm",
+                    "version": "5.0.4"
+                  }
+                }
+              },
+              "com.github.jitpack:root-proj": {
+                "name": "com.github.jitpack:root-proj",
+                "version": "unspecified"
+              }
+            }
+          },
+          "axis:axis": {
+            "name": "axis:axis",
+            "version": "1.3",
+            "dependencies": {
+              "commons-discovery:commons-discovery": {
+                "name": "commons-discovery:commons-discovery",
+                "version": "0.2",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  }
+                }
+              },
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              },
+              "axis:axis-jaxrpc": {
+                "name": "axis:axis-jaxrpc",
+                "version": "1.3"
+              },
+              "axis:axis-saaj": {
+                "name": "axis:axis-saaj",
+                "version": "1.3"
+              },
+              "wsdl4j:wsdl4j": {
+                "name": "wsdl4j:wsdl4j",
+                "version": "1.5.1"
+              }
+            }
+          }
+        },
+        "name": "./subproj",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      },
+      "targetFile": null
+    }
+  ]
+}

--- a/test/fixtures/multi-project-dependency-cycle/expectedTree.json
+++ b/test/fixtures/multi-project-dependency-cycle/expectedTree.json
@@ -1,0 +1,1947 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["root-proj", "subproj"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "com.github.jitpack:subproj": {
+        "name": "com.github.jitpack:subproj",
+        "version": "unspecified",
+        "dependencies": {
+          "com.android.tools.build:builder": {
+            "name": "com.android.tools.build:builder",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.build:manifest-merger": {
+                "name": "com.android.tools.build:manifest-merger",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:sdk-common": {
+                    "name": "com.android.tools:sdk-common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              },
+              "com.android.tools.analytics-library:tracker": {
+                "name": "com.android.tools.analytics-library:tracker",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.android.tools.analytics-library:shared": {
+                    "name": "com.android.tools.analytics-library:shared",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.android.tools.jack:jack-api": {
+                "name": "com.android.tools.jack:jack-api",
+                "version": "0.13.0"
+              },
+              "com.android.tools.jill:jill-api": {
+                "name": "com.android.tools.jill:jill-api",
+                "version": "0.10.0"
+              },
+              "com.squareup:javawriter": {
+                "name": "com.squareup:javawriter",
+                "version": "2.5.0"
+              },
+              "org.ow2.asm:asm-tree": {
+                "name": "org.ow2.asm:asm-tree",
+                "version": "5.0.4",
+                "dependencies": {
+                  "org.ow2.asm:asm": {
+                    "name": "org.ow2.asm:asm",
+                    "version": "5.0.4"
+                  }
+                }
+              },
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "com.google.guava:guava": {
+            "name": "com.google.guava:guava",
+            "version": "18.0"
+          },
+          "batik:batik-dom": {
+            "name": "batik:batik-dom",
+            "version": "1.6"
+          },
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          }
+        }
+      },
+      "com.github.jitpack:root-proj": {
+        "name": "com.github.jitpack:root-proj",
+        "version": "unspecified",
+        "dependencies": {
+          "com.github.jitpack:subproj": {
+            "name": "com.github.jitpack:subproj",
+            "version": "unspecified",
+            "dependencies": {
+              "com.android.tools.build:builder": {
+                "name": "com.android.tools.build:builder",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.build:manifest-merger": {
+                    "name": "com.android.tools.build:manifest-merger",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:sdk-common": {
+                        "name": "com.android.tools:sdk-common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.build:builder-test-api": {
+                            "name": "com.android.tools.build:builder-test-api",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools.ddms:ddmlib": {
+                                "name": "com.android.tools.ddms:ddmlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:sdklib": {
+                            "name": "com.android.tools:sdklib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools.layoutlib:layoutlib-api": {
+                                "name": "com.android.tools.layoutlib:layoutlib-api",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  },
+                                  "net.sf.kxml:kxml2": {
+                                    "name": "net.sf.kxml:kxml2",
+                                    "version": "2.3.0"
+                                  },
+                                  "com.intellij:annotations": {
+                                    "name": "com.intellij:annotations",
+                                    "version": "12.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:dvlib": {
+                                "name": "com.android.tools:dvlib",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "com.android.tools:repository": {
+                                "name": "com.android.tools:repository",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.android.tools:common": {
+                                    "name": "com.android.tools:common",
+                                    "version": "25.3.0",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      },
+                                      "com.android.tools:annotations": {
+                                        "name": "com.android.tools:annotations",
+                                        "version": "25.3.0"
+                                      }
+                                    }
+                                  },
+                                  "com.google.jimfs:jimfs": {
+                                    "name": "com.google.jimfs:jimfs",
+                                    "version": "1.1",
+                                    "dependencies": {
+                                      "com.google.guava:guava": {
+                                        "name": "com.google.guava:guava",
+                                        "version": "18.0"
+                                      }
+                                    }
+                                  },
+                                  "org.apache.commons:commons-compress": {
+                                    "name": "org.apache.commons:commons-compress",
+                                    "version": "1.8.1"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              },
+                              "org.apache.httpcomponents:httpclient": {
+                                "name": "org.apache.httpcomponents:httpclient",
+                                "version": "4.1.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  },
+                                  "commons-codec:commons-codec": {
+                                    "name": "commons-codec:commons-codec",
+                                    "version": "1.4"
+                                  }
+                                }
+                              },
+                              "org.apache.httpcomponents:httpmime": {
+                                "name": "org.apache.httpcomponents:httpmime",
+                                "version": "4.1",
+                                "dependencies": {
+                                  "commons-logging:commons-logging": {
+                                    "name": "commons-logging:commons-logging",
+                                    "version": "1.1.1"
+                                  },
+                                  "org.apache.httpcomponents:httpcore": {
+                                    "name": "org.apache.httpcomponents:httpcore",
+                                    "version": "4.1"
+                                  }
+                                }
+                              },
+                              "com.google.code.gson:gson": {
+                                "name": "com.google.code.gson:gson",
+                                "version": "2.2.4"
+                              }
+                            }
+                          },
+                          "com.android.tools.build:builder-model": {
+                            "name": "com.android.tools.build:builder-model",
+                            "version": "2.3.0",
+                            "dependencies": {
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcpkix-jdk15on": {
+                            "name": "org.bouncycastle:bcpkix-jdk15on",
+                            "version": "1.48",
+                            "dependencies": {
+                              "org.bouncycastle:bcprov-jdk15on": {
+                                "name": "org.bouncycastle:bcprov-jdk15on",
+                                "version": "1.48"
+                              }
+                            }
+                          },
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdk-common": {
+                    "name": "com.android.tools:sdk-common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.build:builder-test-api": {
+                        "name": "com.android.tools.build:builder-test-api",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools.ddms:ddmlib": {
+                            "name": "com.android.tools.ddms:ddmlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:sdklib": {
+                        "name": "com.android.tools:sdklib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools.layoutlib:layoutlib-api": {
+                            "name": "com.android.tools.layoutlib:layoutlib-api",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              },
+                              "net.sf.kxml:kxml2": {
+                                "name": "net.sf.kxml:kxml2",
+                                "version": "2.3.0"
+                              },
+                              "com.intellij:annotations": {
+                                "name": "com.intellij:annotations",
+                                "version": "12.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:dvlib": {
+                            "name": "com.android.tools:dvlib",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "com.android.tools:repository": {
+                            "name": "com.android.tools:repository",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.android.tools:common": {
+                                "name": "com.android.tools:common",
+                                "version": "25.3.0",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  },
+                                  "com.android.tools:annotations": {
+                                    "name": "com.android.tools:annotations",
+                                    "version": "25.3.0"
+                                  }
+                                }
+                              },
+                              "com.google.jimfs:jimfs": {
+                                "name": "com.google.jimfs:jimfs",
+                                "version": "1.1",
+                                "dependencies": {
+                                  "com.google.guava:guava": {
+                                    "name": "com.google.guava:guava",
+                                    "version": "18.0"
+                                  }
+                                }
+                              },
+                              "org.apache.commons:commons-compress": {
+                                "name": "org.apache.commons:commons-compress",
+                                "version": "1.8.1"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          },
+                          "org.apache.httpcomponents:httpclient": {
+                            "name": "org.apache.httpcomponents:httpclient",
+                            "version": "4.1.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              },
+                              "commons-codec:commons-codec": {
+                                "name": "commons-codec:commons-codec",
+                                "version": "1.4"
+                              }
+                            }
+                          },
+                          "org.apache.httpcomponents:httpmime": {
+                            "name": "org.apache.httpcomponents:httpmime",
+                            "version": "4.1",
+                            "dependencies": {
+                              "commons-logging:commons-logging": {
+                                "name": "commons-logging:commons-logging",
+                                "version": "1.1.1"
+                              },
+                              "org.apache.httpcomponents:httpcore": {
+                                "name": "org.apache.httpcomponents:httpcore",
+                                "version": "4.1"
+                              }
+                            }
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          }
+                        }
+                      },
+                      "com.android.tools.build:builder-model": {
+                        "name": "com.android.tools.build:builder-model",
+                        "version": "2.3.0",
+                        "dependencies": {
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcpkix-jdk15on": {
+                        "name": "org.bouncycastle:bcpkix-jdk15on",
+                        "version": "1.48",
+                        "dependencies": {
+                          "org.bouncycastle:bcprov-jdk15on": {
+                            "name": "org.bouncycastle:bcprov-jdk15on",
+                            "version": "1.48"
+                          }
+                        }
+                      },
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  },
+                  "com.android.tools.analytics-library:tracker": {
+                    "name": "com.android.tools.analytics-library:tracker",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.android.tools.analytics-library:shared": {
+                        "name": "com.android.tools.analytics-library:shared",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "com.google.code.gson:gson": {
+                            "name": "com.google.code.gson:gson",
+                            "version": "2.2.4"
+                          },
+                          "com.android.tools.analytics-library:protos": {
+                            "name": "com.android.tools.analytics-library:protos",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.protobuf:protobuf-java": {
+                                "name": "com.google.protobuf:protobuf-java",
+                                "version": "3.0.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      },
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:shared": {
+                    "name": "com.android.tools.analytics-library:shared",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      },
+                      "com.android.tools.analytics-library:protos": {
+                        "name": "com.android.tools.analytics-library:protos",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.protobuf:protobuf-java": {
+                            "name": "com.google.protobuf:protobuf-java",
+                            "version": "3.0.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  },
+                  "com.android.tools.jack:jack-api": {
+                    "name": "com.android.tools.jack:jack-api",
+                    "version": "0.13.0"
+                  },
+                  "com.android.tools.jill:jill-api": {
+                    "name": "com.android.tools.jill:jill-api",
+                    "version": "0.10.0"
+                  },
+                  "com.squareup:javawriter": {
+                    "name": "com.squareup:javawriter",
+                    "version": "2.5.0"
+                  },
+                  "org.ow2.asm:asm-tree": {
+                    "name": "org.ow2.asm:asm-tree",
+                    "version": "5.0.4",
+                    "dependencies": {
+                      "org.ow2.asm:asm": {
+                        "name": "org.ow2.asm:asm",
+                        "version": "5.0.4"
+                      }
+                    }
+                  },
+                  "org.ow2.asm:asm": {
+                    "name": "org.ow2.asm:asm",
+                    "version": "5.0.4"
+                  }
+                }
+              },
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "batik:batik-dom": {
+                "name": "batik:batik-dom",
+                "version": "1.6"
+              },
+              "commons-discovery:commons-discovery": {
+                "name": "commons-discovery:commons-discovery",
+                "version": "0.2",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "root-proj",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-project-parallel/expectedTree.json
+++ b/test/fixtures/multi-project-parallel/expectedTree.json
@@ -1,0 +1,111 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "meta": {}
+  },
+  "scannedProjects": [
+    {
+      "meta": {
+        "gradleProjectName": "root-proj",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj0",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel/subproj0",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj1",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel/subproj1",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj2",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel/subproj2",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj3",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel/subproj3",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj4",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "io.swagger:swagger-annotations": {
+            "name": "io.swagger:swagger-annotations",
+            "version": "1.5.13"
+          }
+        },
+        "name": "multi-project-parallel/subproj4",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      }
+    }
+  ]
+}

--- a/test/fixtures/multi-project-some-unscannable/expectedTree.json
+++ b/test/fixtures/multi-project-some-unscannable/expectedTree.json
@@ -1,0 +1,1010 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "meta": {
+      "allSubProjectNames": [
+        "root-proj",
+        "subproj",
+        "subproj-fail"
+      ]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      },
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      }
+    },
+    "name": "./subproj",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "root-proj/subproj",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-project/configuration-expectedTree.json
+++ b/test/fixtures/multi-project/configuration-expectedTree.json
@@ -1,0 +1,69 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {}
+  },
+  "scannedProjects": [
+    {
+      "meta": {
+        "gradleProjectName": "root-proj",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {},
+        "name": ".",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      },
+      "targetFile": null
+    },
+    {
+      "meta": {
+        "gradleProjectName": "root-proj/subproj",
+        "versionBuildInfo": {}
+      },
+      "depTree": {
+        "dependencies": {
+          "axis:axis": {
+            "name": "axis:axis",
+            "version": "1.3",
+            "dependencies": {
+              "axis:axis-jaxrpc": {
+                "name": "axis:axis-jaxrpc",
+                "version": "1.3"
+              },
+              "axis:axis-saaj": {
+                "name": "axis:axis-saaj",
+                "version": "1.3"
+              },
+              "wsdl4j:wsdl4j": {
+                "name": "wsdl4j:wsdl4j",
+                "version": "1.5.1"
+              },
+              "commons-discovery:commons-discovery": {
+                "name": "commons-discovery:commons-discovery",
+                "version": "0.2",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.0.4"
+                  }
+                }
+              },
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.0.4"
+              }
+            }
+          }
+        },
+        "name": "./subproj",
+        "version": "0.0.0",
+        "packageFormatVersion": "mvn:0.0.1"
+      },
+      "targetFile": null
+    }
+  ]
+}

--- a/test/fixtures/multi-project/expectedTree.json
+++ b/test/fixtures/multi-project/expectedTree.json
@@ -1,0 +1,20 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["root-proj", "subproj"]
+    }
+  },
+  "package": {
+    "dependencies": {},
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "root-proj",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/multi-project/subproj/expectedTree.json
+++ b/test/fixtures/multi-project/subproj/expectedTree.json
@@ -1,0 +1,1007 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["subproj"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "subproj",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/fixtures/no wrapper/expectedTree.json
+++ b/test/fixtures/no wrapper/expectedTree.json
@@ -1,0 +1,1007 @@
+{
+  "plugin": {
+    "name": "bundled:gradle",
+    "runtime": "unknown",
+    "targetFile": null,
+    "meta": {
+      "allSubProjectNames": ["no wrapper"]
+    }
+  },
+  "package": {
+    "dependencies": {
+      "com.google.guava:guava": {
+        "name": "com.google.guava:guava",
+        "version": "18.0"
+      },
+      "batik:batik-dom": {
+        "name": "batik:batik-dom",
+        "version": "1.6"
+      },
+      "commons-discovery:commons-discovery": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2",
+        "dependencies": {
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          }
+        }
+      },
+      "axis:axis": {
+        "name": "axis:axis",
+        "version": "1.3",
+        "dependencies": {
+          "commons-discovery:commons-discovery": {
+            "name": "commons-discovery:commons-discovery",
+            "version": "0.2",
+            "dependencies": {
+              "commons-logging:commons-logging": {
+                "name": "commons-logging:commons-logging",
+                "version": "1.1.1"
+              }
+            }
+          },
+          "commons-logging:commons-logging": {
+            "name": "commons-logging:commons-logging",
+            "version": "1.1.1"
+          },
+          "axis:axis-jaxrpc": {
+            "name": "axis:axis-jaxrpc",
+            "version": "1.3"
+          },
+          "axis:axis-saaj": {
+            "name": "axis:axis-saaj",
+            "version": "1.3"
+          },
+          "wsdl4j:wsdl4j": {
+            "name": "wsdl4j:wsdl4j",
+            "version": "1.5.1"
+          }
+        }
+      },
+      "com.android.tools.build:builder": {
+        "name": "com.android.tools.build:builder",
+        "version": "2.3.0",
+        "dependencies": {
+          "com.android.tools.build:manifest-merger": {
+            "name": "com.android.tools.build:manifest-merger",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:sdk-common": {
+                "name": "com.android.tools:sdk-common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.build:builder-test-api": {
+                    "name": "com.android.tools.build:builder-test-api",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools.ddms:ddmlib": {
+                        "name": "com.android.tools.ddms:ddmlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:sdklib": {
+                    "name": "com.android.tools:sdklib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools.layoutlib:layoutlib-api": {
+                        "name": "com.android.tools.layoutlib:layoutlib-api",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          },
+                          "net.sf.kxml:kxml2": {
+                            "name": "net.sf.kxml:kxml2",
+                            "version": "2.3.0"
+                          },
+                          "com.intellij:annotations": {
+                            "name": "com.intellij:annotations",
+                            "version": "12.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:dvlib": {
+                        "name": "com.android.tools:dvlib",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "com.android.tools:repository": {
+                        "name": "com.android.tools:repository",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.android.tools:common": {
+                            "name": "com.android.tools:common",
+                            "version": "25.3.0",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              },
+                              "com.android.tools:annotations": {
+                                "name": "com.android.tools:annotations",
+                                "version": "25.3.0"
+                              }
+                            }
+                          },
+                          "com.google.jimfs:jimfs": {
+                            "name": "com.google.jimfs:jimfs",
+                            "version": "1.1",
+                            "dependencies": {
+                              "com.google.guava:guava": {
+                                "name": "com.google.guava:guava",
+                                "version": "18.0"
+                              }
+                            }
+                          },
+                          "org.apache.commons:commons-compress": {
+                            "name": "org.apache.commons:commons-compress",
+                            "version": "1.8.1"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      },
+                      "org.apache.httpcomponents:httpclient": {
+                        "name": "org.apache.httpcomponents:httpclient",
+                        "version": "4.1.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          },
+                          "commons-codec:commons-codec": {
+                            "name": "commons-codec:commons-codec",
+                            "version": "1.4"
+                          }
+                        }
+                      },
+                      "org.apache.httpcomponents:httpmime": {
+                        "name": "org.apache.httpcomponents:httpmime",
+                        "version": "4.1",
+                        "dependencies": {
+                          "commons-logging:commons-logging": {
+                            "name": "commons-logging:commons-logging",
+                            "version": "1.1.1"
+                          },
+                          "org.apache.httpcomponents:httpcore": {
+                            "name": "org.apache.httpcomponents:httpcore",
+                            "version": "4.1"
+                          }
+                        }
+                      },
+                      "com.google.code.gson:gson": {
+                        "name": "com.google.code.gson:gson",
+                        "version": "2.2.4"
+                      }
+                    }
+                  },
+                  "com.android.tools.build:builder-model": {
+                    "name": "com.android.tools.build:builder-model",
+                    "version": "2.3.0",
+                    "dependencies": {
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcpkix-jdk15on": {
+                    "name": "org.bouncycastle:bcpkix-jdk15on",
+                    "version": "1.48",
+                    "dependencies": {
+                      "org.bouncycastle:bcprov-jdk15on": {
+                        "name": "org.bouncycastle:bcprov-jdk15on",
+                        "version": "1.48"
+                      }
+                    }
+                  },
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools:sdk-common": {
+            "name": "com.android.tools:sdk-common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.build:builder-test-api": {
+                "name": "com.android.tools.build:builder-test-api",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools.ddms:ddmlib": {
+                    "name": "com.android.tools.ddms:ddmlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:sdklib": {
+                "name": "com.android.tools:sdklib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools.layoutlib:layoutlib-api": {
+                    "name": "com.android.tools.layoutlib:layoutlib-api",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      },
+                      "net.sf.kxml:kxml2": {
+                        "name": "net.sf.kxml:kxml2",
+                        "version": "2.3.0"
+                      },
+                      "com.intellij:annotations": {
+                        "name": "com.intellij:annotations",
+                        "version": "12.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:dvlib": {
+                    "name": "com.android.tools:dvlib",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "com.android.tools:repository": {
+                    "name": "com.android.tools:repository",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.android.tools:common": {
+                        "name": "com.android.tools:common",
+                        "version": "25.3.0",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          },
+                          "com.android.tools:annotations": {
+                            "name": "com.android.tools:annotations",
+                            "version": "25.3.0"
+                          }
+                        }
+                      },
+                      "com.google.jimfs:jimfs": {
+                        "name": "com.google.jimfs:jimfs",
+                        "version": "1.1",
+                        "dependencies": {
+                          "com.google.guava:guava": {
+                            "name": "com.google.guava:guava",
+                            "version": "18.0"
+                          }
+                        }
+                      },
+                      "org.apache.commons:commons-compress": {
+                        "name": "org.apache.commons:commons-compress",
+                        "version": "1.8.1"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  },
+                  "org.apache.httpcomponents:httpclient": {
+                    "name": "org.apache.httpcomponents:httpclient",
+                    "version": "4.1.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      },
+                      "commons-codec:commons-codec": {
+                        "name": "commons-codec:commons-codec",
+                        "version": "1.4"
+                      }
+                    }
+                  },
+                  "org.apache.httpcomponents:httpmime": {
+                    "name": "org.apache.httpcomponents:httpmime",
+                    "version": "4.1",
+                    "dependencies": {
+                      "commons-logging:commons-logging": {
+                        "name": "commons-logging:commons-logging",
+                        "version": "1.1.1"
+                      },
+                      "org.apache.httpcomponents:httpcore": {
+                        "name": "org.apache.httpcomponents:httpcore",
+                        "version": "4.1"
+                      }
+                    }
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  }
+                }
+              },
+              "com.android.tools.build:builder-model": {
+                "name": "com.android.tools.build:builder-model",
+                "version": "2.3.0",
+                "dependencies": {
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "org.bouncycastle:bcpkix-jdk15on": {
+                "name": "org.bouncycastle:bcpkix-jdk15on",
+                "version": "1.48",
+                "dependencies": {
+                  "org.bouncycastle:bcprov-jdk15on": {
+                    "name": "org.bouncycastle:bcprov-jdk15on",
+                    "version": "1.48"
+                  }
+                }
+              },
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "com.android.tools.build:builder-test-api": {
+            "name": "com.android.tools.build:builder-test-api",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools.ddms:ddmlib": {
+                "name": "com.android.tools.ddms:ddmlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.ddms:ddmlib": {
+            "name": "com.android.tools.ddms:ddmlib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "net.sf.kxml:kxml2": {
+                "name": "net.sf.kxml:kxml2",
+                "version": "2.3.0"
+              }
+            }
+          },
+          "com.android.tools:common": {
+            "name": "com.android.tools:common",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "com.android.tools:sdklib": {
+            "name": "com.android.tools:sdklib",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.android.tools.layoutlib:layoutlib-api": {
+                "name": "com.android.tools.layoutlib:layoutlib-api",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "net.sf.kxml:kxml2": {
+                    "name": "net.sf.kxml:kxml2",
+                    "version": "2.3.0"
+                  },
+                  "com.intellij:annotations": {
+                    "name": "com.intellij:annotations",
+                    "version": "12.0"
+                  }
+                }
+              },
+              "com.android.tools:dvlib": {
+                "name": "com.android.tools:dvlib",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools:repository": {
+                "name": "com.android.tools:repository",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.google.jimfs:jimfs": {
+                    "name": "com.google.jimfs:jimfs",
+                    "version": "1.1",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      }
+                    }
+                  },
+                  "org.apache.commons:commons-compress": {
+                    "name": "org.apache.commons:commons-compress",
+                    "version": "1.8.1"
+                  }
+                }
+              },
+              "org.apache.commons:commons-compress": {
+                "name": "org.apache.commons:commons-compress",
+                "version": "1.8.1"
+              },
+              "org.apache.httpcomponents:httpclient": {
+                "name": "org.apache.httpcomponents:httpclient",
+                "version": "4.1.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  },
+                  "commons-codec:commons-codec": {
+                    "name": "commons-codec:commons-codec",
+                    "version": "1.4"
+                  }
+                }
+              },
+              "org.apache.httpcomponents:httpmime": {
+                "name": "org.apache.httpcomponents:httpmime",
+                "version": "4.1",
+                "dependencies": {
+                  "commons-logging:commons-logging": {
+                    "name": "commons-logging:commons-logging",
+                    "version": "1.1.1"
+                  },
+                  "org.apache.httpcomponents:httpcore": {
+                    "name": "org.apache.httpcomponents:httpcore",
+                    "version": "4.1"
+                  }
+                }
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              }
+            }
+          },
+          "com.android.tools.build:builder-model": {
+            "name": "com.android.tools.build:builder-model",
+            "version": "2.3.0",
+            "dependencies": {
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              }
+            }
+          },
+          "org.bouncycastle:bcpkix-jdk15on": {
+            "name": "org.bouncycastle:bcpkix-jdk15on",
+            "version": "1.48",
+            "dependencies": {
+              "org.bouncycastle:bcprov-jdk15on": {
+                "name": "org.bouncycastle:bcprov-jdk15on",
+                "version": "1.48"
+              }
+            }
+          },
+          "org.bouncycastle:bcprov-jdk15on": {
+            "name": "org.bouncycastle:bcprov-jdk15on",
+            "version": "1.48"
+          },
+          "com.android.tools.analytics-library:tracker": {
+            "name": "com.android.tools.analytics-library:tracker",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.android.tools.analytics-library:shared": {
+                "name": "com.android.tools.analytics-library:shared",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:common": {
+                    "name": "com.android.tools:common",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.guava:guava": {
+                        "name": "com.google.guava:guava",
+                        "version": "18.0"
+                      },
+                      "com.android.tools:annotations": {
+                        "name": "com.android.tools:annotations",
+                        "version": "25.3.0"
+                      }
+                    }
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  },
+                  "com.google.code.gson:gson": {
+                    "name": "com.google.code.gson:gson",
+                    "version": "2.2.4"
+                  },
+                  "com.android.tools.analytics-library:protos": {
+                    "name": "com.android.tools.analytics-library:protos",
+                    "version": "25.3.0",
+                    "dependencies": {
+                      "com.google.protobuf:protobuf-java": {
+                        "name": "com.google.protobuf:protobuf-java",
+                        "version": "3.0.0"
+                      }
+                    }
+                  }
+                }
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              },
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.analytics-library:shared": {
+            "name": "com.android.tools.analytics-library:shared",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.guava:guava": {
+                "name": "com.google.guava:guava",
+                "version": "18.0"
+              },
+              "com.android.tools:common": {
+                "name": "com.android.tools:common",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.guava:guava": {
+                    "name": "com.google.guava:guava",
+                    "version": "18.0"
+                  },
+                  "com.android.tools:annotations": {
+                    "name": "com.android.tools:annotations",
+                    "version": "25.3.0"
+                  }
+                }
+              },
+              "com.android.tools:annotations": {
+                "name": "com.android.tools:annotations",
+                "version": "25.3.0"
+              },
+              "com.google.code.gson:gson": {
+                "name": "com.google.code.gson:gson",
+                "version": "2.2.4"
+              },
+              "com.android.tools.analytics-library:protos": {
+                "name": "com.android.tools.analytics-library:protos",
+                "version": "25.3.0",
+                "dependencies": {
+                  "com.google.protobuf:protobuf-java": {
+                    "name": "com.google.protobuf:protobuf-java",
+                    "version": "3.0.0"
+                  }
+                }
+              }
+            }
+          },
+          "com.android.tools.analytics-library:protos": {
+            "name": "com.android.tools.analytics-library:protos",
+            "version": "25.3.0",
+            "dependencies": {
+              "com.google.protobuf:protobuf-java": {
+                "name": "com.google.protobuf:protobuf-java",
+                "version": "3.0.0"
+              }
+            }
+          },
+          "com.android.tools.jack:jack-api": {
+            "name": "com.android.tools.jack:jack-api",
+            "version": "0.13.0"
+          },
+          "com.android.tools.jill:jill-api": {
+            "name": "com.android.tools.jill:jill-api",
+            "version": "0.10.0"
+          },
+          "com.squareup:javawriter": {
+            "name": "com.squareup:javawriter",
+            "version": "2.5.0"
+          },
+          "org.ow2.asm:asm-tree": {
+            "name": "org.ow2.asm:asm-tree",
+            "version": "5.0.4",
+            "dependencies": {
+              "org.ow2.asm:asm": {
+                "name": "org.ow2.asm:asm",
+                "version": "5.0.4"
+              }
+            }
+          },
+          "org.ow2.asm:asm": {
+            "name": "org.ow2.asm:asm",
+            "version": "5.0.4"
+          }
+        }
+      }
+    },
+    "name": ".",
+    "version": "0.0.0",
+    "packageFormatVersion": "mvn:0.0.1"
+  },
+  "meta": {
+    "gradleProjectName": "no wrapper",
+    "versionBuildInfo": {}
+  }
+}

--- a/test/system/kotlin.test.ts
+++ b/test/system/kotlin.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import { fixtureDir } from '../common';
 import { test } from 'tap';
 
@@ -19,9 +20,13 @@ if (kotlinSupported) {
     'build.gradle.kts files are supported',
     { timeout: 150000 },
     async (t) => {
+      const fixturePath = fixtureDir('gradle-kts');
+      const expectedResult = JSON.parse(
+        fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
+      );
       const result = await inspect(
         '.',
-        path.join(fixtureDir('gradle-kts'), 'build.gradle.kts'),
+        path.join(fixturePath, 'build.gradle.kts'),
       );
       t.match(
         result.package.name,
@@ -33,14 +38,7 @@ if (kotlinSupported) {
         'gradle-kts',
         'returned new project name is not sub-project',
       );
-      t.equal(
-        result.package.dependencies!['org.jetbrains.kotlin:kotlin-stdlib-jdk8']
-          .dependencies!['org.jetbrains.kotlin:kotlin-stdlib'].dependencies![
-          'org.jetbrains.kotlin:kotlin-stdlib-common'
-        ].version,
-        '1.3.21',
-        'correct version of a dependency is found',
-      );
+      t.deepEqual(result, expectedResult, 'plugin returned expected result');
       t.equal(
         Object.keys(result.package.dependencies!).length,
         6,

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -3,12 +3,15 @@ import { fixtureDir } from '../common';
 import { test } from 'tap';
 import { inspect } from '../../lib';
 import { legacyPlugin as api } from '@snyk/cli-interface';
+import * as fs from 'fs';
+import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
 
 test('multi-project, explicitly targeting a subproject build file', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project'), 'subproj', 'build.gradle'),
+  const fixturePath = path.join(fixtureDir('multi-project'), 'subproj');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'));
   t.equals(result.package.name, '.', 'root project is "."');
   t.equals(
     result.meta!.gradleProjectName,
@@ -16,26 +19,22 @@ test('multi-project, explicitly targeting a subproject build file', async (t) =>
     'root project is "subproj"',
   );
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
-
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project, ran from root, targeting subproj', async (t) => {
-  const result = await inspect(
-    fixtureDir('multi-project'),
-    'subproj/build.gradle',
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'subproj/expectedTree.json'),
+      'utf-8',
+    ),
   );
+  const result = await inspect(fixturePath, 'subproj/build.gradle');
   t.equals(
     result.package.name,
     'multi-project',
@@ -48,49 +47,43 @@ test('multi-project, ran from root, targeting subproj', async (t) => {
   );
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
 
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project, ran from a subproject directory', async (t) => {
-  const result = await inspect(
-    path.join(fixtureDir('multi-project'), 'subproj'),
-    'build.gradle',
+  const fixturePath = path.join(fixtureDir('multi-project'), 'subproj');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
+  const result = await inspect(fixturePath, 'build.gradle');
   t.equals(result.package.name, 'subproj', 'root project is "subproj"');
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['subproj']);
 
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project: only sub-project has deps and they are returned', async (t) => {
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'subproj/expectedTree.json'),
+      'utf-8',
+    ),
+  );
   const options = {
     subProject: 'subproj',
   };
   const result = await inspect(
     '.',
-    path.join(fixtureDir('multi-project'), 'build.gradle'),
+    path.join(fixturePath, 'build.gradle'),
     options,
   );
   t.match(
@@ -100,25 +93,19 @@ test('multi-project: only sub-project has deps and they are returned', async (t)
   );
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
 
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project: only sub-project has deps, none returned for main', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project'), 'build.gradle'),
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'));
   t.match(result.package.name, '.', 'returned project name is not sub-project');
   t.match(
     result.meta!.gradleProjectName,
@@ -126,9 +113,11 @@ test('multi-project: only sub-project has deps, none returned for main', async (
     'returned new project name is not sub-project',
   );
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
-  if (result.package.dependencies) {
-    t.ok(Object.keys(result.package.dependencies).length === 0);
-  }
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
+  );
 });
 
 let wrapperIsCompatibleWithJvm = true;
@@ -169,11 +158,10 @@ if (wrapperIsCompatibleWithJvm) {
 }
 
 test('multi-project: parallel is handled correctly', async (t) => {
+  const fixturePath = fixtureDir('multi-project-parallel');
+
   // Note: Gradle has to be run from the directory with `gradle.properties` to pick that one up
-  const result = await inspect(
-    fixtureDir('multi-project-parallel'),
-    'build.gradle',
-  );
+  const result = await inspect(fixturePath, 'build.gradle');
   t.match(
     result.package.name,
     'multi-project-parallel',
@@ -184,106 +172,84 @@ test('multi-project: parallel is handled correctly', async (t) => {
     'root-proj',
     'expected new project name',
   );
-  t.ok(result.package.dependencies);
+  t.equal(
+    result.package.dependencies,
+    {},
+    'plugin did not return expected result',
+  );
 });
 
 test('multi-project: only sub-project has deps and they are returned space needs trimming', async (t) => {
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'subproj/expectedTree.json'),
+      'utf-8',
+    ),
+  );
   const options = {
     subProject: 'subproj ',
   };
   const result = await inspect(
     '.',
-    path.join(fixtureDir('multi-project'), 'build.gradle'),
+    path.join(fixturePath, 'build.gradle'),
     options,
   );
 
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
 
-  t.match(
-    result.package.name,
-    '/subproj',
-    'sub project name is included in the root pkg name',
-  );
-
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project: deps for both projects are returned with allSubProjects flag', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project'), 'build.gradle'),
-    { allSubProjects: true },
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'configuration-expectedTree.json'),
+      'utf-8',
+    ),
   );
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'), {
+    allSubProjects: true,
+  });
   // It's an array, so we have to scan
   t.equal(result.scannedProjects.length, 2);
-  for (const p of result.scannedProjects) {
-    if (p.depTree.name === '.') {
-      t.equal(p.meta!.gradleProjectName, 'root-proj', 'new project name');
-      if (p.depTree.dependencies) {
-        t.ok(
-          Object.keys(p.depTree.dependencies).length === 0,
-          'no dependencies for the main depRoot',
-        );
-      }
-      t.notOk(p.targetFile, 'no target file returned'); // see targetFileFilteredForCompatibility
-      // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-      // t.match(p.targetFile, 'multi-project' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
-    } else {
-      t.equal(
-        p.depTree.name,
-        './subproj',
-        'sub project name is included in the root pkg name',
-      );
-      t.equal(
-        p.meta!.gradleProjectName,
-        'root-proj/subproj',
-        'new sub project name is included in the root pkg name',
-      );
-      t.equal(
-        p.depTree.dependencies!['com.android.tools.build:builder']
-          .dependencies!['com.android.tools.build:manifest-merger']
-          .dependencies!['com.android.tools:sdk-common'].dependencies![
-          'com.android.tools.build:builder-test-api'
-        ].dependencies!['com.android.tools.ddms:ddmlib'].dependencies![
-          'com.android.tools:common'
-        ].dependencies!['com.android.tools:annotations'].version,
-        '25.3.0',
-        'correct version found',
-      );
-      t.notOk(p.targetFile, 'no target file returned'); // see targetFileFilteredForCompatibility
-      // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-      // t.match(p.targetFile, 'subproj' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
-    }
-  }
+  t.deepEqual(
+    result.scannedProjects[0].depTree,
+    expectedResult.scannedProjects[0].depTree,
+    'plugin did not return expected result',
+  );
+  t.deepEqual(
+    result.scannedProjects[1].depTree,
+    expectedResult.scannedProjects[1].depTree,
+    'plugin did not return expected result',
+  );
 });
 
 test('single-project: array of one is returned with allSubProjects flag', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('api-configuration'), 'build.gradle'),
-    { allSubProjects: true },
+  const fixturePath = fixtureDir('api-configuration');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
+
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'), {
+    allSubProjects: true,
+  });
   t.equal(result.scannedProjects.length, 1);
   t.equal(result.scannedProjects[0].depTree.name, '.');
   t.equal(
     result.scannedProjects[0].meta!.gradleProjectName,
     'api-configuration',
   );
-  t.ok(
-    result.scannedProjects[0].depTree.dependencies![
-      'commons-httpclient:commons-httpclient'
-    ],
+  t.equal(result.scannedProjects.length, 1, 'expected one sub project');
+  t.deepEqual(
+    result.scannedProjects[0].depTree,
+    expectedResult.scannedProjects[0].depTree,
+    'plugin did not return expected result',
   );
 });
 
@@ -298,12 +264,16 @@ test('multi-project-some-unscannable: allSubProjects fails', async (t) => {
 });
 
 test('multi-project-some-unscannable: gradle-sub-project for a good subproject works', async (t) => {
+  const fixturePath = fixtureDir('multi-project-some-unscannable');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
+  );
   const options = {
     subProject: 'subproj ',
   };
   const result = await inspect(
     '.',
-    path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'),
+    path.join(fixturePath, 'build.gradle'),
     options,
   );
 
@@ -319,17 +289,10 @@ test('multi-project-some-unscannable: gradle-sub-project for a good subproject w
     'sub project name is included in the root pkg name',
   );
 
-  t.equal(
-    result.package.dependencies!['com.android.tools.build:builder']
-      .dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'correct version found',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
@@ -344,96 +307,63 @@ test('allSubProjects incompatible with gradle-sub-project', async (t) => {
 
 test('multi-project: parallel with allSubProjects produces multiple results with different names', async (t) => {
   // Note: Gradle has to be run from the directory with `gradle.properties` to pick that one up
-  const result = await inspect(
-    fixtureDir('multi-project-parallel'),
-    'build.gradle',
-    { allSubProjects: true },
+  const NUMBER_AVAILABLE_PROJECTS = 6;
+  const fixturePath = fixtureDir('multi-project-parallel');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
-  t.equal(result.scannedProjects.length, 6);
-  const names = new Set<string>();
-  const newNames = new Set<string>();
-  for (const p of result.scannedProjects) {
-    names.add(p.depTree.name!);
-    newNames.add(p.meta!.gradleProjectName);
-    t.ok(p.meta!.versionBuildInfo.gradleVersion !== null);
+  const result = await inspect(fixturePath, 'build.gradle', {
+    allSubProjects: true,
+  });
+
+  t.equal(result.scannedProjects.length, NUMBER_AVAILABLE_PROJECTS);
+  for (let i = 0; i < NUMBER_AVAILABLE_PROJECTS; i++) {
+    t.deepEqual(
+      result.scannedProjects[i],
+      expectedResult.scannedProjects[i],
+      'plugin did not return expected result',
+    );
   }
-  t.deepEqual(
-    names,
-    new Set<string>([
-      'multi-project-parallel',
-      'multi-project-parallel/subproj0',
-      'multi-project-parallel/subproj1',
-      'multi-project-parallel/subproj2',
-      'multi-project-parallel/subproj3',
-      'multi-project-parallel/subproj4',
-    ]),
-  );
-  t.deepEqual(
-    newNames,
-    new Set<string>([
-      'root-proj',
-      'root-proj/subproj0',
-      'root-proj/subproj1',
-      'root-proj/subproj2',
-      'root-proj/subproj3',
-      'root-proj/subproj4',
-    ]),
-  );
 });
 
 test('multi-project: allSubProjects + configuration', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project'), 'build.gradle'),
-    { allSubProjects: true, args: ['--configuration', 'compileOnly'] },
+  const fixturePath = fixtureDir('multi-project');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'configuration-expectedTree.json'),
+      'utf-8',
+    ),
   );
-  // It's an array, so we have to scan
-  t.equal(result.scannedProjects.length, 2);
-  for (const p of result.scannedProjects) {
-    if (p.depTree.name === '.') {
-      t.equal(p.meta!.gradleProjectName, 'root-proj', 'new project name');
-      if (p.depTree.dependencies) {
-        t.ok(
-          Object.keys(p.depTree.dependencies).length === 0,
-          'no dependencies for the main depRoot',
-        );
-      }
-      t.notOk(p.targetFile, 'no target file returned'); // see targetFileFilteredForCompatibility
-      // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-      // t.match(p.targetFile, 'multi-project' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
-    } else {
-      t.equal(
-        p.depTree.name,
-        './subproj',
-        'sub project name is included in the root pkg name',
-      );
-      t.equal(
-        p.meta!.gradleProjectName,
-        'root-proj/subproj',
-        'new sub project name is included in the root pkg name',
-      );
-      t.equal(
-        p.depTree.dependencies!['axis:axis'].version,
-        '1.3',
-        'correct version found',
-      );
-      t.notOk(
-        p.depTree.dependencies!['com.android.tools.build:builder'],
-        'non-compileOnly dependency is not found',
-      );
-      t.notOk(p.targetFile, 'no target file returned'); // see targetFileFilteredForCompatibility
-      // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-      // t.match(p.targetFile, 'subproj' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
-    }
-  }
+  const options = {
+    allSubProjects: true,
+    args: ['--configuration', 'compileOnly'],
+  };
+
+  const result = ((await inspect(
+    '.',
+    path.join(fixturePath, 'build.gradle'),
+    options,
+  )) as unknown) as MultiProjectResult;
+  t.equal(result.scannedProjects.length, 2, 'expected two sub projects');
+  t.deepEqual(
+    result.scannedProjects[0],
+    expectedResult.scannedProjects[0],
+    'plugin did not return expected result',
+  );
+  t.deepEqual(
+    result.scannedProjects[1],
+    expectedResult.scannedProjects[1],
+    'plugin did not return expected result',
+  );
 });
 
 test('multi-project-dependency-cycle: scanning the main project works fine', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project-dependency-cycle'), 'build.gradle'),
-    {},
+  const fixturePath = fixtureDir('multi-project-dependency-cycle');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(path.join(fixturePath, 'expectedTree.json'), 'utf-8'),
   );
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'), {});
+
   t.equal(result.package.name, '.', 'root project name is "."');
   t.equal(
     result.meta!.gradleProjectName,
@@ -441,46 +371,34 @@ test('multi-project-dependency-cycle: scanning the main project works fine', asy
     'new root project name is "root-proj"',
   );
   t.deepEqual(result.plugin.meta!.allSubProjectNames, ['root-proj', 'subproj']);
-
-  t.notOk(
-    result.package.dependencies!['com.github.jitpack:subproj'].dependencies![
-      'com.github.jitpack:root-proj'
-    ],
-    'dependency cycle for sub-project is not returned in results',
-  );
-
-  t.equal(
-    result.package.dependencies!['com.github.jitpack:subproj'].dependencies![
-      'com.android.tools.build:builder'
-    ].dependencies!['com.android.tools.build:manifest-merger'].dependencies![
-      'com.android.tools:sdk-common'
-    ].dependencies!['com.android.tools.build:builder-test-api'].dependencies![
-      'com.android.tools.ddms:ddmlib'
-    ].dependencies!['com.android.tools:common'].dependencies![
-      'com.android.tools:annotations'
-    ].version,
-    '25.3.0',
-    'a dependency chain is found through subproj dependency',
+  t.deepEqual(
+    result.package.dependencies,
+    expectedResult.package.dependencies,
+    'plugin did not return expected result',
   );
 });
 
 test('multi-project-dependency-cycle: scanning all subprojects works fine', async (t) => {
-  const result = await inspect(
-    '.',
-    path.join(fixtureDir('multi-project-dependency-cycle'), 'build.gradle'),
-    { allSubProjects: true },
+  const fixturePath = fixtureDir('multi-project-dependency-cycle');
+  const expectedResult = JSON.parse(
+    fs.readFileSync(
+      path.join(fixturePath, 'allSubProjects-expectedTree.json'),
+      'utf-8',
+    ),
   );
-  // It's an array, so we have to scan
-  t.equal(result.scannedProjects.length, 2);
-  for (const p of result.scannedProjects) {
-    if (p.depTree.name === '.') {
-      t.equal(p.meta!.gradleProjectName, 'root-proj', 'new project name');
-      t.ok(
-        p.depTree.dependencies!['com.github.jitpack:subproj'].dependencies![
-          'com.android.tools.build:builder'
-        ],
-        'dependency cycle is not returned for the main',
-      );
-    }
-  }
+
+  const result = await inspect('.', path.join(fixturePath, 'build.gradle'), {
+    allSubProjects: true,
+  });
+  t.equal(result.scannedProjects.length, 2, 'expected two sub projects');
+  t.deepEqual(
+    result.scannedProjects[0].depTree,
+    expectedResult.scannedProjects[0].depTree,
+    'plugin did not return expected result',
+  );
+  t.deepEqual(
+    result.scannedProjects[1].depTree,
+    expectedResult.scannedProjects[1].depTree,
+    'plugin did not return expected result',
+  );
 });

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -9,7 +9,7 @@
       "module": "commonjs",
       "allowJs": false,
       "sourceMap": true,
-      "strict": true,
+      "strict": false,
       "declaration": true,
       "importHelpers": true,
       "typeRoots": ["./node_modules/@types", "./typings"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "module": "commonjs",
       "allowJs": false,
       "sourceMap": true,
-      "strict": true,
+      "strict": false,
       "declaration": true,
       "importHelpers": true,
       "typeRoots": ["./node_modules/@types", "./typings"],


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The goal of this pr is to convert all tests using the `expected-fixtures`.
afterwards, we will create another pr where we convert these `expected-fixtures` to graphs using depGraph library to be used by https://github.com/snyk/snyk/pull/1165

