### PR TITLE
feat: send back sub-project targetFile

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -372,6 +372,7 @@ async function getAllDepsAllProjects(
       meta: {
         gradleProjectName,
         versionBuildInfo: allProjectDeps.versionBuildInfo,
+        targetFile: allProjectDeps.projects[proj].targetFile,
       },
       depGraph: allProjectDeps.projects[proj].depGraph,
     };

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^3.9.2"
   },
   "dependencies": {
-    "@snyk/cli-interface": "2.8.0",
+    "@snyk/cli-interface": "2.9.0",
     "@snyk/dep-graph": "^1.19.0",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Send back targetFile as meta so we can still use the information for messaging and other purposes without sending it to the backend where it is not expected for `build.gradle`
This allows a feature that compares detected vs scanned gradle projects to help identify issues or orphaned build files.
https://github.com/snyk/snyk/pull/1355/files