### PR TITLE
feat: always print attributes on error with -d

### DIFF
--- a/lib/gradle-attributes-pretty.ts
+++ b/lib/gradle-attributes-pretty.ts
@@ -1,0 +1,42 @@
+import * as chalk from 'chalk';
+
+export function getGradleAttributesPretty(output: string): string | undefined {
+  try {
+    const lines = output.split('\n');
+
+    if (lines === null) {
+      return undefined;
+    }
+    let jsonLine: string | null = null;
+    lines.forEach((l) => {
+      const line = l.trim();
+      // Extract attribute information via JSONATTRS marker:
+      if (/^JSONATTRS /.test(line)) {
+        if (jsonLine === null) {
+          jsonLine = line.substr(10);
+        }
+      }
+    });
+
+    const jsonAttrs = JSON.parse(jsonLine);
+    const attrNameWidth = Math.max(
+      ...Object.keys(jsonAttrs).map((name) => name.length),
+    );
+    const jsonAttrsPretty = Object.keys(jsonAttrs)
+      .map(
+        (name) =>
+          chalk.whiteBright(leftPad(name, attrNameWidth)) +
+          ': ' +
+          chalk.gray(jsonAttrs[name].join(', ')),
+      )
+      .join('\n');
+    return jsonAttrsPretty;
+  } catch (e) {
+    return undefined;
+  }
+}
+
+// <insert a npm left-pad joke here>
+function leftPad(s: string, n: number) {
+  return ' '.repeat(Math.max(n - s.length, 0)) + s;
+}

--- a/test/functional/gradle-plugin.test.ts
+++ b/test/functional/gradle-plugin.test.ts
@@ -118,6 +118,25 @@ test('extractJsonFromScriptOutput throws on multiple JSONDEPS', async (t) => {
   }
 });
 
+test('getGradleAttributesPretty returns undefined when throws', async (t) => {
+  const result = testableMethods.getGradleAttributesPretty(``);
+  t.deepEqual(result, undefined);
+});
+
+test('getGradleAttributesPretty returns attributes on success', async (t) => {
+  const result = testableMethods.getGradleAttributesPretty(
+    `SNYKECHO snykResolvedDepsJson task is executing via doLast
+    JSONATTRS {"org.gradle.usage":["java-runtime","java-api"],"org.gradle.category":["library"],"org.gradle.libraryelements":["jar"],"org.gradle.dependency.bundling":["external"]}
+    SNYKECHO processing project: subproj`,
+  );
+  t.deepEqual(
+    result,
+    `              org.gradle.usage: java-runtime, java-api
+           org.gradle.category: library
+    org.gradle.libraryelements: jar
+org.gradle.dependency.bundling: external`,
+  );
+});
 test('check build args (plain console output)', async (t) => {
   const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {});
   t.deepEqual(result, [


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Extract all the attributes on error & for `-d` mode which helps with Android scans to narrow down the buildType + flavour to scan. The attributes help construct the correct `--attributes-matching` parameter

<img width="1437" alt="Screen Shot 2020-10-07 at 18 30 33" src="https://user-images.githubusercontent.com/2911613/95435821-f81fde00-094a-11eb-9a97-076967854d5e.png">
