### PR TITLE
fix: update java-call-graph-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
     "@snyk/dep-graph": "^1.19.4",
-    "@snyk/java-call-graph-builder": "1.16.0",
+    "@snyk/java-call-graph-builder": "1.16.2",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
Updates to the new snyk-config version that should get shipped with the CLI first.

Requirement for snyk/snyk#1524
Follow up to the snyk/config#43 and https://github.com/snyk/java-call-graph-builder/pull/37