### PR TITLE
feat: pass gradle util to java call graph builder

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -113,9 +113,11 @@ export async function inspect(
   let callGraph: CallGraph | undefined;
   const targetPath = path.join(root, targetFile);
   if (options.reachableVulns) {
+    const command = getCommand(root, targetFile);
     debugLog(`getting call graph from path ${targetPath}`);
     callGraph = await javaCallGraphBuilder.getCallGraphGradle(
       path.dirname(targetPath),
+      command,
     );
     debugLog('got call graph successfully');
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
     "@snyk/dep-graph": "^1.19.4",
-    "@snyk/java-call-graph-builder": "1.16.2",
+    "@snyk/java-call-graph-builder": "1.18.0",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -49,7 +49,10 @@ test('run inspect() with reachableVulns', async (t) => {
   );
   t.ok(javaCallGraphBuilderStub.calledOnce, 'called to the call graph builder');
   t.ok(
-    javaCallGraphBuilderStub.calledWith(path.join('.', rootNoWrapper)),
+    javaCallGraphBuilderStub.calledWith(
+      path.join('.', rootNoWrapper),
+      'gradle',
+    ),
     'call graph builder was called with the correct path',
   );
   t.same(gradleCallGraph, result.callGraph, 'returns expected callgraph');


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We want to make sure that the right gradle util is being used within the java call graph builder to allow gradle
sub projects to use the correct gradlew, which can be found in the root of the project.

For more context go to
https://github.com/snyk/java-call-graph-builder/pull/42


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-564

