### PR TITLE
chore: update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 .github
 .jscsrc
-.travis.yml
 /test


### PR DESCRIPTION
Remove travis.yml from npmignore as it no longer exists.
