### PR TITLE
feat: several fixes for gradle+android rechability analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
     "@snyk/dep-graph": "^1.19.4",
-    "@snyk/java-call-graph-builder": "1.18.0",
+    "@snyk/java-call-graph-builder": "1.19.0",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Updates `java-call-graph-builder` to 1.19, which brings a couple fixes on how read and parse application's classpath.


#### Any background context you want to provide?
https://github.com/snyk/java-call-graph-builder/pull/45

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-575