### PR TITLE
fix: scanning lock due of unresolved deps

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -4,7 +4,7 @@ import java.util.regex.Matcher
 import org.gradle.util.GradleVersion
 
 // Snyk dependency resolution script for Gradle.
-// Tested on Gradle versions from 2.14 to 5.4.1
+// Tested on Gradle versions from v2.14 to v6.8.1
 
 // This script does the following: for all the projects in the build file,
 // generate a merged configuration of all the available configurations,
@@ -129,6 +129,19 @@ def getSnykGraph(Iterable deps) {
     return graph.nodes
 }
 
+def configsSuccessfullyResolved(configurations) { 
+    def resolvedConfigurations = [];
+    configurations.each({ configuration ->
+           try {
+            configuration.resolve();
+            resolvedConfigurations.add(configuration);
+           } catch(Exception ex) {    
+            println('NOT_RESOLVED ' + ex.toString())
+           }
+    })
+    return resolvedConfigurations;
+}
+
 // We are attaching this task to every project, as this is the only reliable way to run it
 // when we start with a subproject build.gradle. As a consequence, we need to make sure we
 // only ever run it once, for the "starting" project.
@@ -218,7 +231,8 @@ allprojects { everyProj ->
                 rootProject.allprojects.findAll(shouldScanProject).each { proj ->
                     println('SNYKECHO processing project: ' + proj.name)
 
-                    def snykConf = null 
+                    def projectConfigs = null 
+                    def filteredProjectConfigs = null
 
                     // Gradle v3.0+ contains concepts as attributes, config canBeResolved, that does not exist in legacy versions
                     final GradleVersion gradleVersionInUse = GradleVersion.current();
@@ -230,40 +244,40 @@ allprojects { everyProj ->
                         // we can compute a dependency graph and that contains all the necessary information for resolution to happen.
                         if (confAttrSpec != null) {
                             // Drop all the configrations that don't match the attribute filter
-                            snykConf = proj.configurations
-                            .findAll({ it.canBeResolved == true && it.canBeConsumed == false && it.name =~ confNameFilter && matchesAttributeFilter(it)  })
+                            filteredProjectConfigs = proj.configurations.findAll({ it.canBeResolved == true && it.canBeConsumed == false && it.name =~ confNameFilter && matchesAttributeFilter(it)  })
 
-                            if(snykConf.size() == 0) {
-                                snykConf = proj.configurations
+                            if(filteredProjectConfigs.size() == 0) {
+                                filteredProjectConfigs = proj.configurations
                                 .findAll({ it.canBeResolved == true && it.canBeConsumed == true && it.name =~ confNameFilter && matchesAttributeFilter(it) })
                             }
 
+                        projectConfigs = configsSuccessfullyResolved(filteredProjectConfigs)
                         } else {
-                            snykConf = proj.configurations
-                            .findAll({ it.canBeResolved == true && it.canBeConsumed == false && it.name =~ confNameFilter  })
-
                             // if we cannot find dependencies that can be only resolved but not consumable
                             // we try to find configs that are simultaneously resolvable and consumable
                             // to prevent dependency resolution conflicts (e.g. Cannot choose between the following variants) 
                             // we avoid the coexistence of (canBeResolved: true, canBeConsumed: false) and (canBeResolved: true, canBeConsumed: true) configs
-                            if(snykConf.size() == 0) {
-                                snykConf = proj.configurations
+                            filteredProjectConfigs = proj.configurations.findAll({ it.canBeResolved == true && it.canBeConsumed == false && it.name =~ confNameFilter  })
+                            if(filteredProjectConfigs.size() == 0) {
+                                filteredProjectConfigs = proj.configurations
                                 .findAll({ it.canBeResolved == true && it.canBeConsumed == true && it.name =~ confNameFilter  })
                             }
+                            projectConfigs =  configsSuccessfullyResolved(filteredProjectConfigs)
                         }       
                     } else {
-                        snykConf = proj.configurations.findAll({ it.name =~ confNameFilter })
+                        def configsFilteredByConfName = proj.configurations.findAll({ it.name =~ confNameFilter })
+                        projectConfigs =  configsSuccessfullyResolved(configsFilteredByConfName)
                     }
                 
-                    if (snykConf.size() == 0 && proj.configurations.size() > 0) {
+                    if (projectConfigs.size() == 0 && proj.configurations.size() > 0) {
                         throw new RuntimeException('Matching configurations not found: ' + confNameFilter +
                                 ', available configurations for project ' + proj + ': '
                                 + proj.configurations.collect { it.name })
                     }
 
-                    if (snykConf != null) {
-                        println('SNYKECHO resolving configuration ' + snykConf.name)
-                        def gradleFirstLevelDeps = snykConf.resolvedConfiguration.firstLevelModuleDependencies
+                    if (projectConfigs != null) {
+                        println('SNYKECHO resolving configuration ' + projectConfigs.name)
+                        def gradleFirstLevelDeps = projectConfigs.resolvedConfiguration.firstLevelModuleDependencies.findAll({ it.size() > 0 })
                         println('SNYKECHO converting gradle graph to snyk-graph format')
                         projectsDict[proj.name] = [
                             'targetFile': findProject(proj.path).buildFile.toString(),

--- a/test/fixtures/successful-scan-with-unresolved-custom-configs/build.gradle
+++ b/test/fixtures/successful-scan-with-unresolved-custom-configs/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'io.gatling.gradle' version "3.5.0"
+}
+
+build.dependsOn gatlingClasses
+
+dependencies {
+    gatling group: 'org.scalaj', name: 'scalaj-http_2.13', version: '2.4.2'
+}
+
+gatling {
+    simulations = {
+        exclude "**/paxos/BaseSimulation.scala"
+        exclude "**/paxos/Configuration.scala"
+    }
+}

--- a/test/fixtures/successful-scan-with-unresolved-custom-configs/expected-depgraph.json
+++ b/test/fixtures/successful-scan-with-unresolved-custom-configs/expected-depgraph.json
@@ -1,0 +1,925 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": { "name": "gradle" },
+  "pkgs": [
+    {
+      "id": ".@unspecified",
+      "info": { "name": ".", "version": "unspecified" }
+    },
+    {
+      "id": "org.scalaj:scalaj-http_2.13@2.4.2",
+      "info": { "name": "org.scalaj:scalaj-http_2.13", "version": "2.4.2" }
+    },
+    {
+      "id": "org.scala-lang:scala-library@2.13.4",
+      "info": { "name": "org.scala-lang:scala-library", "version": "2.13.4" }
+    },
+    {
+      "id": "io.gatling.highcharts:gatling-charts-highcharts@3.5.0",
+      "info": {
+        "name": "io.gatling.highcharts:gatling-charts-highcharts",
+        "version": "3.5.0"
+      }
+    },
+    {
+      "id": "io.gatling:gatling-app@3.5.0",
+      "info": { "name": "io.gatling:gatling-app", "version": "3.5.0" }
+    },
+    {
+      "id": "io.gatling:gatling-http@3.5.0",
+      "info": { "name": "io.gatling:gatling-http", "version": "3.5.0" }
+    },
+    {
+      "id": "io.gatling:gatling-core@3.5.0",
+      "info": { "name": "io.gatling:gatling-core", "version": "3.5.0" }
+    },
+    {
+      "id": "com.typesafe.akka:akka-slf4j_2.13@2.6.10",
+      "info": {
+        "name": "com.typesafe.akka:akka-slf4j_2.13",
+        "version": "2.6.10"
+      }
+    },
+    {
+      "id": "com.typesafe.akka:akka-actor_2.13@2.6.10",
+      "info": {
+        "name": "com.typesafe.akka:akka-actor_2.13",
+        "version": "2.6.10"
+      }
+    },
+    {
+      "id": "org.scala-lang.modules:scala-java8-compat_2.13@0.9.0",
+      "info": {
+        "name": "org.scala-lang.modules:scala-java8-compat_2.13",
+        "version": "0.9.0"
+      }
+    },
+    {
+      "id": "com.typesafe:config@1.4.1",
+      "info": { "name": "com.typesafe:config", "version": "1.4.1" }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.30",
+      "info": { "name": "org.slf4j:slf4j-api", "version": "1.7.30" }
+    },
+    {
+      "id": "io.gatling:gatling-commons@3.5.0",
+      "info": { "name": "io.gatling:gatling-commons", "version": "3.5.0" }
+    },
+    {
+      "id": "io.gatling:gatling-commons-shared-unstable@3.5.0",
+      "info": {
+        "name": "io.gatling:gatling-commons-shared-unstable",
+        "version": "3.5.0"
+      }
+    },
+    {
+      "id": "io.gatling:gatling-commons-shared@3.5.0",
+      "info": {
+        "name": "io.gatling:gatling-commons-shared",
+        "version": "3.5.0"
+      }
+    },
+    {
+      "id": "io.gatling:gatling-netty-util@3.5.0",
+      "info": { "name": "io.gatling:gatling-netty-util", "version": "3.5.0" }
+    },
+    {
+      "id": "io.netty:netty-transport-native-epoll@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-transport-native-epoll",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport-native-unix-common@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-transport-native-unix-common",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport@4.1.55.Final",
+      "info": { "name": "io.netty:netty-transport", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-buffer@4.1.55.Final",
+      "info": { "name": "io.netty:netty-buffer", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-common@4.1.55.Final",
+      "info": { "name": "io.netty:netty-common", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-resolver@4.1.55.Final",
+      "info": { "name": "io.netty:netty-resolver", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "org.scala-lang:scala-reflect@2.13.3",
+      "info": { "name": "org.scala-lang:scala-reflect", "version": "2.13.3" }
+    },
+    {
+      "id": "io.suzaku:boopickle_2.13@1.3.3",
+      "info": { "name": "io.suzaku:boopickle_2.13", "version": "1.3.3" }
+    },
+    {
+      "id": "org.typelevel:spire-macros_2.13@0.17.0",
+      "info": { "name": "org.typelevel:spire-macros_2.13", "version": "0.17.0" }
+    },
+    {
+      "id": "com.typesafe.scala-logging:scala-logging_2.13@3.9.2",
+      "info": {
+        "name": "com.typesafe.scala-logging:scala-logging_2.13",
+        "version": "3.9.2"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-classic@1.2.3",
+      "info": { "name": "ch.qos.logback:logback-classic", "version": "1.2.3" }
+    },
+    {
+      "id": "ch.qos.logback:logback-core@1.2.3",
+      "info": { "name": "ch.qos.logback:logback-core", "version": "1.2.3" }
+    },
+    {
+      "id": "io.gatling:gatling-jsonpath@3.5.0",
+      "info": { "name": "io.gatling:gatling-jsonpath", "version": "3.5.0" }
+    },
+    {
+      "id": "org.scala-lang.modules:scala-parser-combinators_2.13@1.1.2",
+      "info": {
+        "name": "org.scala-lang.modules:scala-parser-combinators_2.13",
+        "version": "1.1.2"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-databind@2.12.0",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "2.12.0"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-annotations@2.12.0",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-annotations",
+        "version": "2.12.0"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson:jackson-bom@2.12.0",
+      "info": {
+        "name": "com.fasterxml.jackson:jackson-bom",
+        "version": "2.12.0"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-core@2.12.0",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-core",
+        "version": "2.12.0"
+      }
+    },
+    {
+      "id": "com.github.scopt:scopt_2.13@3.7.1",
+      "info": { "name": "com.github.scopt:scopt_2.13", "version": "3.7.1" }
+    },
+    {
+      "id": "com.softwaremill.quicklens:quicklens_2.13@1.6.1",
+      "info": {
+        "name": "com.softwaremill.quicklens:quicklens_2.13",
+        "version": "1.6.1"
+      }
+    },
+    {
+      "id": "io.burt:jmespath-jackson@0.5.0",
+      "info": { "name": "io.burt:jmespath-jackson", "version": "0.5.0" }
+    },
+    {
+      "id": "io.burt:jmespath-core@0.5.0",
+      "info": { "name": "io.burt:jmespath-core", "version": "0.5.0" }
+    },
+    {
+      "id": "org.simpleflatmapper:lightning-csv@8.2.3",
+      "info": {
+        "name": "org.simpleflatmapper:lightning-csv",
+        "version": "8.2.3"
+      }
+    },
+    {
+      "id": "org.simpleflatmapper:sfm-util@8.2.3",
+      "info": { "name": "org.simpleflatmapper:sfm-util", "version": "8.2.3" }
+    },
+    {
+      "id": "com.github.ben-manes.caffeine:caffeine@2.8.8",
+      "info": {
+        "name": "com.github.ben-manes.caffeine:caffeine",
+        "version": "2.8.8"
+      }
+    },
+    {
+      "id": "org.checkerframework:checker-qual@3.8.0",
+      "info": {
+        "name": "org.checkerframework:checker-qual",
+        "version": "3.8.0"
+      }
+    },
+    {
+      "id": "com.google.errorprone:error_prone_annotations@2.4.0",
+      "info": {
+        "name": "com.google.errorprone:error_prone_annotations",
+        "version": "2.4.0"
+      }
+    },
+    {
+      "id": "io.pebbletemplates:pebble@3.1.4",
+      "info": { "name": "io.pebbletemplates:pebble", "version": "3.1.4" }
+    },
+    {
+      "id": "org.unbescape:unbescape@1.1.6.RELEASE",
+      "info": { "name": "org.unbescape:unbescape", "version": "1.1.6.RELEASE" }
+    },
+    {
+      "id": "io.netty:netty-handler@4.1.55.Final",
+      "info": { "name": "io.netty:netty-handler", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-codec@4.1.55.Final",
+      "info": { "name": "io.netty:netty-codec", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "net.sf.saxon:Saxon-HE@10.3",
+      "info": { "name": "net.sf.saxon:Saxon-HE", "version": "10.3" }
+    },
+    {
+      "id": "org.jodd:jodd-lagarto@6.0.2",
+      "info": { "name": "org.jodd:jodd-lagarto", "version": "6.0.2" }
+    },
+    {
+      "id": "org.jodd:jodd-util@6.0.0",
+      "info": { "name": "org.jodd:jodd-util", "version": "6.0.0" }
+    },
+    {
+      "id": "io.gatling:gatling-http-client@3.5.0",
+      "info": { "name": "io.gatling:gatling-http-client", "version": "3.5.0" }
+    },
+    {
+      "id": "io.netty:netty-handler-proxy@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-handler-proxy",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-codec-http@4.1.55.Final",
+      "info": { "name": "io.netty:netty-codec-http", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-codec-socks@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-codec-socks",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-codec-http2@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-codec-http2",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-resolver-dns@4.1.55.Final",
+      "info": {
+        "name": "io.netty:netty-resolver-dns",
+        "version": "4.1.55.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-codec-dns@4.1.55.Final",
+      "info": { "name": "io.netty:netty-codec-dns", "version": "4.1.55.Final" }
+    },
+    {
+      "id": "io.netty:netty-tcnative-boringssl-static@2.0.35.Final",
+      "info": {
+        "name": "io.netty:netty-tcnative-boringssl-static",
+        "version": "2.0.35.Final"
+      }
+    },
+    {
+      "id": "io.gatling:gatling-jms@3.5.0",
+      "info": { "name": "io.gatling:gatling-jms", "version": "3.5.0" }
+    },
+    {
+      "id": "javax.jms:javax.jms-api@2.0.1",
+      "info": { "name": "javax.jms:javax.jms-api", "version": "2.0.1" }
+    },
+    {
+      "id": "com.eatthepath:fast-uuid@0.1",
+      "info": { "name": "com.eatthepath:fast-uuid", "version": "0.1" }
+    },
+    {
+      "id": "io.gatling:gatling-jdbc@3.5.0",
+      "info": { "name": "io.gatling:gatling-jdbc", "version": "3.5.0" }
+    },
+    {
+      "id": "io.gatling:gatling-redis@3.5.0",
+      "info": { "name": "io.gatling:gatling-redis", "version": "3.5.0" }
+    },
+    {
+      "id": "net.debasishg:redisclient_2.13@3.30",
+      "info": { "name": "net.debasishg:redisclient_2.13", "version": "3.30" }
+    },
+    {
+      "id": "org.apache.commons:commons-pool2@2.8.0",
+      "info": { "name": "org.apache.commons:commons-pool2", "version": "2.8.0" }
+    },
+    {
+      "id": "io.gatling:gatling-graphite@3.5.0",
+      "info": { "name": "io.gatling:gatling-graphite", "version": "3.5.0" }
+    },
+    {
+      "id": "org.hdrhistogram:HdrHistogram@2.1.12",
+      "info": { "name": "org.hdrhistogram:HdrHistogram", "version": "2.1.12" }
+    },
+    {
+      "id": "io.gatling:gatling-charts@3.5.0",
+      "info": { "name": "io.gatling:gatling-charts", "version": "3.5.0" }
+    },
+    {
+      "id": "com.tdunning:t-digest@3.1",
+      "info": { "name": "com.tdunning:t-digest", "version": "3.1" }
+    },
+    {
+      "id": "io.gatling:gatling-recorder@3.5.0",
+      "info": { "name": "io.gatling:gatling-recorder", "version": "3.5.0" }
+    },
+    {
+      "id": "org.scala-lang.modules:scala-swing_2.13@3.0.0",
+      "info": {
+        "name": "org.scala-lang.modules:scala-swing_2.13",
+        "version": "3.0.0"
+      }
+    },
+    {
+      "id": "org.bouncycastle:bcpkix-jdk15on@1.67",
+      "info": { "name": "org.bouncycastle:bcpkix-jdk15on", "version": "1.67" }
+    },
+    {
+      "id": "org.bouncycastle:bcprov-jdk15on@1.67",
+      "info": { "name": "org.bouncycastle:bcprov-jdk15on", "version": "1.67" }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": ".@unspecified",
+        "deps": [
+          { "nodeId": "org.scalaj:scalaj-http_2.13@2.4.2" },
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "io.gatling.highcharts:gatling-charts-highcharts@3.5.0" },
+          { "nodeId": "io.gatling:gatling-app@3.5.0" },
+          { "nodeId": "io.gatling:gatling-http@3.5.0" },
+          { "nodeId": "io.gatling:gatling-core@3.5.0" },
+          { "nodeId": "com.typesafe.akka:akka-actor_2.13@2.6.10" },
+          { "nodeId": "io.gatling:gatling-commons@3.5.0" },
+          { "nodeId": "io.gatling:gatling-commons-shared@3.5.0" },
+          { "nodeId": "io.netty:netty-transport-native-epoll@4.1.55.Final" },
+          { "nodeId": "com.typesafe.scala-logging:scala-logging_2.13@3.9.2" },
+          { "nodeId": "ch.qos.logback:logback-classic@1.2.3" },
+          { "nodeId": "com.fasterxml.jackson.core:jackson-databind@2.12.0" },
+          { "nodeId": "io.burt:jmespath-jackson@0.5.0" },
+          { "nodeId": "org.simpleflatmapper:lightning-csv@8.2.3" },
+          { "nodeId": "com.github.ben-manes.caffeine:caffeine@2.8.8" },
+          { "nodeId": "io.pebbletemplates:pebble@3.1.4" },
+          { "nodeId": "org.jodd:jodd-lagarto@6.0.2" },
+          { "nodeId": "io.gatling:gatling-http-client@3.5.0" },
+          { "nodeId": "io.netty:netty-handler-proxy@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-resolver-dns@4.1.55.Final" },
+          { "nodeId": "io.gatling:gatling-jms@3.5.0" },
+          { "nodeId": "io.gatling:gatling-redis@3.5.0" },
+          { "nodeId": "net.debasishg:redisclient_2.13@3.30" },
+          { "nodeId": "io.gatling:gatling-graphite@3.5.0" },
+          { "nodeId": "io.gatling:gatling-charts@3.5.0" },
+          { "nodeId": "io.gatling:gatling-recorder@3.5.0" },
+          { "nodeId": "org.bouncycastle:bcpkix-jdk15on@1.67" }
+        ]
+      },
+      {
+        "nodeId": "org.scalaj:scalaj-http_2.13@2.4.2",
+        "pkgId": "org.scalaj:scalaj-http_2.13@2.4.2",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "org.scala-lang:scala-library@2.13.4",
+        "pkgId": "org.scala-lang:scala-library@2.13.4",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling.highcharts:gatling-charts-highcharts@3.5.0",
+        "pkgId": "io.gatling.highcharts:gatling-charts-highcharts@3.5.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "io.gatling:gatling-app@3.5.0",
+        "pkgId": "io.gatling:gatling-app@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "io.gatling:gatling-jdbc@3.5.0" }
+        ]
+      },
+      {
+        "nodeId": "io.gatling:gatling-http@3.5.0",
+        "pkgId": "io.gatling:gatling-http@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "net.sf.saxon:Saxon-HE@10.3" }
+        ]
+      },
+      {
+        "nodeId": "io.gatling:gatling-core@3.5.0",
+        "pkgId": "io.gatling:gatling-core@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "com.typesafe.akka:akka-slf4j_2.13@2.6.10" },
+          { "nodeId": "io.gatling:gatling-jsonpath@3.5.0" },
+          {
+            "nodeId": "org.scala-lang.modules:scala-parser-combinators_2.13@1.1.2"
+          },
+          { "nodeId": "com.github.scopt:scopt_2.13@3.7.1" },
+          { "nodeId": "com.softwaremill.quicklens:quicklens_2.13@1.6.1" },
+          { "nodeId": "io.netty:netty-handler@4.1.55.Final" },
+          { "nodeId": "net.sf.saxon:Saxon-HE@10.3" }
+        ]
+      },
+      {
+        "nodeId": "com.typesafe.akka:akka-slf4j_2.13@2.6.10",
+        "pkgId": "com.typesafe.akka:akka-slf4j_2.13@2.6.10",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" }
+        ]
+      },
+      {
+        "nodeId": "com.typesafe.akka:akka-actor_2.13@2.6.10",
+        "pkgId": "com.typesafe.akka:akka-actor_2.13@2.6.10",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.scala-lang.modules:scala-java8-compat_2.13@0.9.0" },
+          { "nodeId": "com.typesafe:config@1.4.1" }
+        ]
+      },
+      {
+        "nodeId": "org.scala-lang.modules:scala-java8-compat_2.13@0.9.0",
+        "pkgId": "org.scala-lang.modules:scala-java8-compat_2.13@0.9.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "com.typesafe:config@1.4.1",
+        "pkgId": "com.typesafe:config@1.4.1",
+        "deps": []
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api@1.7.30",
+        "pkgId": "org.slf4j:slf4j-api@1.7.30",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-commons@3.5.0",
+        "pkgId": "io.gatling:gatling-commons@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "com.typesafe:config@1.4.1" },
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "io.gatling:gatling-commons-shared-unstable@3.5.0" },
+          { "nodeId": "org.typelevel:spire-macros_2.13@0.17.0" }
+        ]
+      },
+      {
+        "nodeId": "io.gatling:gatling-commons-shared-unstable@3.5.0",
+        "pkgId": "io.gatling:gatling-commons-shared-unstable@3.5.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "io.gatling:gatling-commons-shared@3.5.0",
+        "pkgId": "io.gatling:gatling-commons-shared@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "io.gatling:gatling-netty-util@3.5.0" },
+          { "nodeId": "org.scala-lang:scala-reflect@2.13.3" },
+          { "nodeId": "io.suzaku:boopickle_2.13@1.3.3" }
+        ]
+      },
+      {
+        "nodeId": "io.gatling:gatling-netty-util@3.5.0",
+        "pkgId": "io.gatling:gatling-netty-util@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport-native-epoll@4.1.55.Final",
+        "pkgId": "io.netty:netty-transport-native-epoll@4.1.55.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-transport-native-unix-common@4.1.55.Final"
+          },
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport-native-unix-common@4.1.55.Final",
+        "pkgId": "io.netty:netty-transport-native-unix-common@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport@4.1.55.Final",
+        "pkgId": "io.netty:netty-transport@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-resolver@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-buffer@4.1.55.Final",
+        "pkgId": "io.netty:netty-buffer@4.1.55.Final",
+        "deps": [{ "nodeId": "io.netty:netty-common@4.1.55.Final" }]
+      },
+      {
+        "nodeId": "io.netty:netty-common@4.1.55.Final",
+        "pkgId": "io.netty:netty-common@4.1.55.Final",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-resolver@4.1.55.Final",
+        "pkgId": "io.netty:netty-resolver@4.1.55.Final",
+        "deps": [{ "nodeId": "io.netty:netty-common@4.1.55.Final" }]
+      },
+      {
+        "nodeId": "org.scala-lang:scala-reflect@2.13.3",
+        "pkgId": "org.scala-lang:scala-reflect@2.13.3",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "io.suzaku:boopickle_2.13@1.3.3",
+        "pkgId": "io.suzaku:boopickle_2.13@1.3.3",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "org.typelevel:spire-macros_2.13@0.17.0",
+        "pkgId": "org.typelevel:spire-macros_2.13@0.17.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "com.typesafe.scala-logging:scala-logging_2.13@3.9.2",
+        "pkgId": "com.typesafe.scala-logging:scala-logging_2.13@3.9.2",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "org.scala-lang:scala-reflect@2.13.3" }
+        ]
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-classic@1.2.3",
+        "pkgId": "ch.qos.logback:logback-classic@1.2.3",
+        "deps": [
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "ch.qos.logback:logback-core@1.2.3" }
+        ]
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-core@1.2.3",
+        "pkgId": "ch.qos.logback:logback-core@1.2.3",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-jsonpath@3.5.0",
+        "pkgId": "io.gatling:gatling-jsonpath@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          {
+            "nodeId": "org.scala-lang.modules:scala-parser-combinators_2.13@1.1.2"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.scala-lang.modules:scala-parser-combinators_2.13@1.1.2",
+        "pkgId": "org.scala-lang.modules:scala-parser-combinators_2.13@1.1.2",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-databind@2.12.0",
+        "pkgId": "com.fasterxml.jackson.core:jackson-databind@2.12.0",
+        "deps": [
+          { "nodeId": "com.fasterxml.jackson.core:jackson-annotations@2.12.0" },
+          { "nodeId": "com.fasterxml.jackson:jackson-bom@2.12.0" },
+          { "nodeId": "com.fasterxml.jackson.core:jackson-core@2.12.0" }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-annotations@2.12.0",
+        "pkgId": "com.fasterxml.jackson.core:jackson-annotations@2.12.0",
+        "deps": [{ "nodeId": "com.fasterxml.jackson:jackson-bom@2.12.0" }]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson:jackson-bom@2.12.0",
+        "pkgId": "com.fasterxml.jackson:jackson-bom@2.12.0",
+        "deps": []
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-core@2.12.0",
+        "pkgId": "com.fasterxml.jackson.core:jackson-core@2.12.0",
+        "deps": [{ "nodeId": "com.fasterxml.jackson:jackson-bom@2.12.0" }]
+      },
+      {
+        "nodeId": "com.github.scopt:scopt_2.13@3.7.1",
+        "pkgId": "com.github.scopt:scopt_2.13@3.7.1",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "com.softwaremill.quicklens:quicklens_2.13@1.6.1",
+        "pkgId": "com.softwaremill.quicklens:quicklens_2.13@1.6.1",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "io.burt:jmespath-jackson@0.5.0",
+        "pkgId": "io.burt:jmespath-jackson@0.5.0",
+        "deps": [{ "nodeId": "io.burt:jmespath-core@0.5.0" }]
+      },
+      {
+        "nodeId": "io.burt:jmespath-core@0.5.0",
+        "pkgId": "io.burt:jmespath-core@0.5.0",
+        "deps": []
+      },
+      {
+        "nodeId": "org.simpleflatmapper:lightning-csv@8.2.3",
+        "pkgId": "org.simpleflatmapper:lightning-csv@8.2.3",
+        "deps": [{ "nodeId": "org.simpleflatmapper:sfm-util@8.2.3" }]
+      },
+      {
+        "nodeId": "org.simpleflatmapper:sfm-util@8.2.3",
+        "pkgId": "org.simpleflatmapper:sfm-util@8.2.3",
+        "deps": []
+      },
+      {
+        "nodeId": "com.github.ben-manes.caffeine:caffeine@2.8.8",
+        "pkgId": "com.github.ben-manes.caffeine:caffeine@2.8.8",
+        "deps": [
+          { "nodeId": "org.checkerframework:checker-qual@3.8.0" },
+          { "nodeId": "com.google.errorprone:error_prone_annotations@2.4.0" }
+        ]
+      },
+      {
+        "nodeId": "org.checkerframework:checker-qual@3.8.0",
+        "pkgId": "org.checkerframework:checker-qual@3.8.0",
+        "deps": []
+      },
+      {
+        "nodeId": "com.google.errorprone:error_prone_annotations@2.4.0",
+        "pkgId": "com.google.errorprone:error_prone_annotations@2.4.0",
+        "deps": []
+      },
+      {
+        "nodeId": "io.pebbletemplates:pebble@3.1.4",
+        "pkgId": "io.pebbletemplates:pebble@3.1.4",
+        "deps": [
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "org.unbescape:unbescape@1.1.6.RELEASE" }
+        ]
+      },
+      {
+        "nodeId": "org.unbescape:unbescape@1.1.6.RELEASE",
+        "pkgId": "org.unbescape:unbescape@1.1.6.RELEASE",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-handler@4.1.55.Final",
+        "pkgId": "io.netty:netty-handler@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-resolver@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec@4.1.55.Final",
+        "pkgId": "io.netty:netty-codec@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "net.sf.saxon:Saxon-HE@10.3",
+        "pkgId": "net.sf.saxon:Saxon-HE@10.3",
+        "deps": []
+      },
+      {
+        "nodeId": "org.jodd:jodd-lagarto@6.0.2",
+        "pkgId": "org.jodd:jodd-lagarto@6.0.2",
+        "deps": [
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "org.jodd:jodd-util@6.0.0" }
+        ]
+      },
+      {
+        "nodeId": "org.jodd:jodd-util@6.0.0",
+        "pkgId": "org.jodd:jodd-util@6.0.0",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-http-client@3.5.0",
+        "pkgId": "io.gatling:gatling-http-client@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "io.gatling:gatling-netty-util@3.5.0" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-handler@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-http@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-http2@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-tcnative-boringssl-static@2.0.35.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-handler-proxy@4.1.55.Final",
+        "pkgId": "io.netty:netty-handler-proxy@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-http@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-socks@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec-http@4.1.55.Final",
+        "pkgId": "io.netty:netty-codec-http@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-handler@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec-socks@4.1.55.Final",
+        "pkgId": "io.netty:netty-codec-socks@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec-http2@4.1.55.Final",
+        "pkgId": "io.netty:netty-codec-http2@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-handler@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-http@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-resolver-dns@4.1.55.Final",
+        "pkgId": "io.netty:netty-resolver-dns@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-resolver@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-handler@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec-dns@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec-dns@4.1.55.Final",
+        "pkgId": "io.netty:netty-codec-dns@4.1.55.Final",
+        "deps": [
+          { "nodeId": "io.netty:netty-transport@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-buffer@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-common@4.1.55.Final" },
+          { "nodeId": "io.netty:netty-codec@4.1.55.Final" }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static@2.0.35.Final",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.35.Final",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-jms@3.5.0",
+        "pkgId": "io.gatling:gatling-jms@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "javax.jms:javax.jms-api@2.0.1" },
+          { "nodeId": "com.eatthepath:fast-uuid@0.1" }
+        ]
+      },
+      {
+        "nodeId": "javax.jms:javax.jms-api@2.0.1",
+        "pkgId": "javax.jms:javax.jms-api@2.0.1",
+        "deps": []
+      },
+      {
+        "nodeId": "com.eatthepath:fast-uuid@0.1",
+        "pkgId": "com.eatthepath:fast-uuid@0.1",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-jdbc@3.5.0",
+        "pkgId": "io.gatling:gatling-jdbc@3.5.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "io.gatling:gatling-redis@3.5.0",
+        "pkgId": "io.gatling:gatling-redis@3.5.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "net.debasishg:redisclient_2.13@3.30",
+        "pkgId": "net.debasishg:redisclient_2.13@3.30",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.slf4j:slf4j-api@1.7.30" },
+          { "nodeId": "org.apache.commons:commons-pool2@2.8.0" }
+        ]
+      },
+      {
+        "nodeId": "org.apache.commons:commons-pool2@2.8.0",
+        "pkgId": "org.apache.commons:commons-pool2@2.8.0",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-graphite@3.5.0",
+        "pkgId": "io.gatling:gatling-graphite@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "org.hdrhistogram:HdrHistogram@2.1.12" }
+        ]
+      },
+      {
+        "nodeId": "org.hdrhistogram:HdrHistogram@2.1.12",
+        "pkgId": "org.hdrhistogram:HdrHistogram@2.1.12",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-charts@3.5.0",
+        "pkgId": "io.gatling:gatling-charts@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "com.tdunning:t-digest@3.1" }
+        ]
+      },
+      {
+        "nodeId": "com.tdunning:t-digest@3.1",
+        "pkgId": "com.tdunning:t-digest@3.1",
+        "deps": []
+      },
+      {
+        "nodeId": "io.gatling:gatling-recorder@3.5.0",
+        "pkgId": "io.gatling:gatling-recorder@3.5.0",
+        "deps": [
+          { "nodeId": "org.scala-lang:scala-library@2.13.4" },
+          { "nodeId": "io.netty:netty-codec-http@4.1.55.Final" },
+          { "nodeId": "org.scala-lang.modules:scala-swing_2.13@3.0.0" }
+        ]
+      },
+      {
+        "nodeId": "org.scala-lang.modules:scala-swing_2.13@3.0.0",
+        "pkgId": "org.scala-lang.modules:scala-swing_2.13@3.0.0",
+        "deps": [{ "nodeId": "org.scala-lang:scala-library@2.13.4" }]
+      },
+      {
+        "nodeId": "org.bouncycastle:bcpkix-jdk15on@1.67",
+        "pkgId": "org.bouncycastle:bcpkix-jdk15on@1.67",
+        "deps": [{ "nodeId": "org.bouncycastle:bcprov-jdk15on@1.67" }]
+      },
+      {
+        "nodeId": "org.bouncycastle:bcprov-jdk15on@1.67",
+        "pkgId": "org.bouncycastle:bcprov-jdk15on@1.67",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/test/manual/unresolved-configs.spec.ts
+++ b/test/manual/unresolved-configs.spec.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { inspect } from '../../lib';
+import { fixtureDir } from '../common';
+import { createFromJSON } from '@snyk/dep-graph';
+
+const JEST_TIMEOUT = 10000;
+// Bear in mind that unresolvable configs e.g. incrementalScalaAnalysisForgatling cannot compute a depGraph,
+// for this reason we should just ignore it instead of make the whole process fail, since it provide no info to be scanned
+describe('successful scan gradle projects even if they contain submodules with unresolvable configs', () => {
+  it(
+    'multi-project-some-unscannable: allSubProjects pass even if a single subproj is unresolved',
+    async () => {
+      const result = await inspect(
+        '.',
+        path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'),
+        { allSubProjects: true },
+      );
+
+      // sub-project success has resolved deps while sub-proj-fail that was unresolved and root with no deps will have 0 deps
+      expect(result.scannedProjects[1].depGraph.getDepPkgs().length).toBe(41);
+    },
+    JEST_TIMEOUT,
+  );
+
+  it('should successfully scan even if some custom configs are unresolvable (cannot compute depGraph)', async () => {
+    const buildGradle = path.join(
+      fixtureDir('successful-scan-with-unresolved-custom-configs'),
+      'build.gradle',
+    );
+
+    const expectedDepGraphJSON = fs.readFileSync(
+      path.join(
+        fixtureDir('successful-scan-with-unresolved-custom-configs'),
+        'expected-depgraph.json',
+      ),
+      'utf-8',
+    );
+    const expectedDepGraph = createFromJSON(JSON.parse(expectedDepGraphJSON));
+
+    const data = await inspect('.', buildGradle);
+    const depGraph = data.dependencyGraph;
+
+    const allPathsAreReacheableFromRoot = depGraph
+      .getPkgs()
+      .reduce((acc, pkg) => acc + depGraph.countPathsToRoot(pkg), 0);
+
+    expect(allPathsAreReacheableFromRoot).toBeTruthy();
+    expect(depGraph.equals(expectedDepGraph)).toBeTruthy();
+  });
+});

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -299,16 +299,6 @@ test('single-project: array of one is returned with allSubProjects flag', async 
   t.ok(nodeIds.indexOf('commons-httpclient:commons-httpclient@3.1') !== -1);
 });
 
-test('multi-project-some-unscannable: allSubProjects fails', async (t) => {
-  await t.rejects(
-    inspect(
-      '.',
-      path.join(fixtureDir('multi-project-some-unscannable'), 'build.gradle'),
-      { allSubProjects: true },
-    ),
-  );
-});
-
 test('multi-project-some-unscannable: gradle-sub-project for a good subproject works', async (t) => {
   const options = {
     subProject: 'subproj ',


### PR DESCRIPTION
- Renamed snykConf to projectConfigs, to improve the readability

- Created configsSuccessfullyResolved method that confirms if
  configs sets as canBeResolved=true, can be really resolved or not.

  If there is an error now, while resolving configs set as
  canBeResolved=true, we are no longer blocking the scanning. We ignore
  those configs whose depGraph cannot be computed and move forward with the
  scanning process since it's not a snyk issue but a given gradle project
  resolution config caused by bad config or 3rd party gradle dependencies bad behaving.
  
By going into `test/fixtures/successful-scan-with-unresolved-custom-configs/build.gradle` and running `gradle -q dependencies` you will see the following message (pic below)

This fixture emulates issue gradle/gradle#6854, **where gradle cannot resolve incremental analysis configurations**.

<img width="638" alt="Screen Shot 2021-01-31 at 18 54 04" src="https://user-images.githubusercontent.com/40601533/106393164-d369dd80-63f5-11eb-9335-bcc1716b890a.png">

What does **FAILED** means? Means any dependency belonging to these configuratios failed to be resolved (compute depGraph)

Continue reading about failed resolution in Gradle Docs.. https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#example_rendering_the_dependency_report_for_a_custom_configuration


