### PR TITLE
fix: more than one line with jsondeps

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -136,7 +136,7 @@ def configsSuccessfullyResolved(configurations) {
             configuration.resolve();
             resolvedConfigurations.add(configuration);
            } catch(Exception ex) {    
-            println('NOT_RESOLVED ' + ex.toString())
+             // Swallowing it
            }
     })
     return resolvedConfigurations;


### PR DESCRIPTION
- swallowing unresolvable configs error msg in order to prevent mass spam in
script output while scanning projects with large graph output to prevent parse errors...