### PR TITLE
fix: graceful resolvable configs

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -133,7 +133,7 @@ def configsSuccessfullyResolved(configurations) {
     def resolvedConfigurations = [];
     configurations.each({ configuration ->
            try {
-            configuration.resolve();
+            configuration.resolvedConfiguration.firstLevelModuleDependencies;
             resolvedConfigurations.add(configuration);
            } catch(Exception ex) {    
              // Swallowing it


### PR DESCRIPTION
making configsSuccessfullyResolved more graceful, when at least a single
dependency available in a config failed e.g. 1/5, we immediately were
considering the config not resolvable and filtering it out.
By using configuration.resolvedConfiguration.firstLevelModuleDependencies;
We no longer try to locate and download files as we were doing with
configuration.resolve. With the new approach we just ask for the instances
available for each direct dependency of the configuration that matches the given spec.
Continue reading https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedConfiguration.html