### PR TITLE
init-script arg added to InspectResult API

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -85,6 +85,7 @@ export async function inspect(
 export async function inspect(
   root: string,
   targetFile: string,
+  initFile: string,
   options?: Options,
 ): Promise<api.InspectResult> {
   debugLog(
@@ -112,11 +113,13 @@ export async function inspect(
 
   let callGraph: CallGraph | undefined;
   const targetPath = path.join(root, targetFile);
+  const initPath = path.join(root, initFile);
   if (options.reachableVulns) {
     const command = getCommand(root, targetFile);
     debugLog(`getting call graph from path ${targetPath}`);
     callGraph = await javaCallGraphBuilder.getCallGraphGradle(
       path.dirname(targetPath),
+      path.dirname(initPath),
       command,
     );
     debugLog('got call graph successfully');


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Following the issue with init-script mentioned in the following Zendesk ticket, I added `init-script` argument to `InspectResult` API.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

##### Fix Snyk Gradle Call-graph Builder issue  
After I noticed the issue in both Android and t24-service projects, I decided to take a close look at code path and fix the issue myself. 

##### Stacktrace  


```bash
SubprocessError: The command "'/builds/varo-bank/server/banking/t24-service/gradlew' printClasspath -I /usr/local/lib/node_modules/snyk/node_modules/@snyk/java-call-graph-builder/bin/init.gradle -q -p /builds/varo-bank/server/banking/t24-service" exited with code 1, Standard Error Output: , FAILURE: Build failed with an exception., , * Where:, Build file '/builds/varo-bank/server/banking/t24-service/build.gradle.kts' line: 3
    at ChildProcess.<anonymous> (/usr/local/lib/node_modules/snyk/node_modules/@snyk/java-call-graph-builder/lib/sub-process.ts:56:21)
    at ChildProcess.emit (events.js:315:20)
    at maybeClose (internal/child_process.js:1048:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
Error: 
Monitoring /builds/varo-bank/server/banking/t24-service...

Could not determine the project's class path. Please contact our support or submit an issue at https://github.com/snyk/java-call-graph-builder/issues. Re-running the command with the `-d` flag will provide useful information for the support engineers.
    at monitor (/usr/local/lib/node_modules/snyk/src/cli/commands/monitor/index.ts:297:9)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at runCommand (/usr/local/lib/node_modules/snyk/src/cli/index.ts:53:25)
    at main (/usr/local/lib/node_modules/snyk/src/cli/index.ts:298:11)

```  

It seems the subprocess tasks failed because returned with a non-zero exit code. I took the `java-call-graph-builder/lib/sub-process.ts:56:21` as a clue and started my investigation.  

Here is the code around the location:  

```ts
export function execute(
  command: string,
  args: string[],
  options?: { cwd: string },
):
...
const proc = childProcess.spawn(command, args, spawnOptions);
...
    if (proc.stderr) {
      proc.stderr.on('data', (data) => {
        stderr += data;
      });
    }
```  

I grepped for any instance of `execute(` in `java-call-graph-builder` and found the following candidates:  

```     
./lib/java-wrapper.ts:        execute('java', callgraphGenCommandArgs, {
./lib/gradle-wrapper.ts:    const output = await execute(gradlePath, args, { cwd: targetPath });
./lib/mvn-wrapper.ts:  return execute('mvn', args.concat(['-f', projectDirectory]), {
./lib/sub-process.ts:export function execute(
./lib/mvn-wrapper-legacy.ts:      const output = await execute('mvn', args, { cwd: targetPath });
./lib/mvn-wrapper-legacy.ts:      const output = await execute('mvn', args, { cwd: targetPath });
```  

Since we are dealing with a gradle build, `gradle-wrapper.ts` took my attention. Here is the code:  

```ts
export function getGradleCommandArgs(targetPath: string): string[] {
  const gradleArgs = [
    'printClasspath',
    '-I',
    path.join(__dirname, ...'../bin/init.gradle'.split('/')),
    '-q',
  ];
  if (targetPath) {
    gradleArgs.push('-p', targetPath);
  }

  return gradleArgs;
}

export async function getClassPathFromGradle(
  targetPath: string,
  gradlePath: string,
): Promise<string> {
  const args = getGradleCommandArgs(targetPath);
  try {
    const output = await execute(gradlePath, args, { cwd: targetPath });
    return output.trim();
  } catch (e) {
    console.log(e);
    throw new ClassPathGenerationError(e);
  }
}

```  

Nice! Here they exported two functions `getGradleCommandArgs` and `getClassPathFromGradle`. When I looked at the Gitlab console logs, the following line came faimilar to the above string construction for `printClasspath`.  

```
/builds/varo-bank/server/banking/t24-service/gradlew' printClasspath -I /usr/local/lib/node_modules/snyk/node_modules/@snyk/java-call-graph-builder/bin/init.gradle -q -p /builds/varo-bank/server/banking/t24-service
```  

When I ran the above command in console, build process failed. I noticed that snyk monitor won't pass additional arguments to `./gradlew`. Since we are using JFrog artifactory, to authenticate gradle to rely on JFrog artifactory we need to pass the following `init-script`:  

`--init-script ./varo-bank-init/gradle/init.gradle.kts`  

Which simply grabs USERNAME and PASSWORD from vault and authenticate artifactory in our environment.  To pass additional arguments to `gradle`, based on the snyk documents, one needs to pass it like the following:  


source: https://support.snyk.io/hc/en-us/articles/360001781957-How-do-I-pass-commands-through-snyk-to-the-package-manager-

```snyk [options] [command] [package] -- "[arguments"```  

Here is what we pass in `gitlab-ci.yml`:  

```yml
variables:
  SERVICE_NAME: t24

stages:
  - snyk

dependencyScanning:
  stage: snyk
  allow_failure: true
  only:
    refs:
      - branches
  tags:
    - snyk
  script:
# snyk monitor
    - snyk monitor -d --file=./build.gradle.kts --insecure  --severity-threshold=medium --reachable -- "--init-script ./varo-bank-init/gradle/init.gradle.kts" >> log.txt 
 
```  

**Note**: That `--reachable` functionality is what we are testinf for here.  

Anyways, based on the Gitlab console log, snyk won't pass our argument to `gradlew` sub-processes.  To make sure our assumption is correct, when we run the faulting module with `--init-script` it works without any error:  

```
./gradlew --init-script ./varo-bank-init/gradle/init.gradle.kts printClasspath -I /usr/local/lib/node_modules/snyk/node_modules/@snyk/java-call-graph-builder/bin/init.gradle --debug -q -p .


init.gradle.kts using ARTIFACTORY_USER env variable username=[MASKED]
/builds/varo-bank/server/banking/t24-service/build/classes/java/main:/builds/varo-bank/server/banking/t24-service/build/classes/kotlin/main:/builds/varo-bank/server/banking/t24-service/build/resources/main:/home/snyk/.gradle/caches/modules-2/files-2.1/com.varobank.common/common-kafka/6.2.0/d26389dbfb0300d2f4a15e5743f94aa4b0e9ba48/common-kafka-6.2.0.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/com.fasterxml.jackson.module/jackson-module-kotlin/2.11.3/ad8d29545c5ab0cdd6d49ee38f7ece8d9f772815/jackson-module-kotlin-2.11.3.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/com.varobank.common/grpc-common/3.1.2/216bf463dca062c8abdc52b73abed33c748540e1/grpc-common-3.1.2.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/com.varobank.common/common-audit/0.1.2/6f51e4863d452d7dd440afa74437e955a93e95fa/common-audit-0.1.2.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/com.varobank.common/common-kotlin/0.5.0/e431047dcec60c13be3fb1d733d6acad4850c265/common-kotlin-0.5.0.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.21/748f681f4e3edbe9285ff46710c79049c70f4dfa/kotlin-reflect-1.4.21.jar:/home/snyk/.gradle/caches/modules-2/files-2.1/org.jetbrains
```  

Basically `printClasspath` prints out the classpath for our java project:  

```ts
task printClasspath {
        doLast {
            def classPath = [].toSet();

            pluginManager.withPlugin('java') {
                classPath = sourceSets.main.runtimeClasspath.asPath
            }
```  

Following our path in code, we look for instances of `getClassPathFromGradle()` call in whole snyk code base and we found the following match in `java-call-graph-builder/lib/index.ts#getCallGraphGradle`. We need to pass one more argument to `getCallGraphGradle` rather than `targetPath`. I would like to name it `initScript`.  

```ts
export async function getCallGraphGradle(
  targetPath: string,
  gradlePath = 'gradle',
  timeout?: number,
): Promise<Graph> {
  const [classPath, targets] = await Promise.all([
    timeIt('getGradleClassPath', () =>
      getClassPathFromGradle(targetPath, gradlePath),
    ),
    timeIt('getEntrypoints', () => findBuildDirs(targetPath, 'gradle')),
  ]);

  return await timeIt('getCallGraph', () =>
    getCallGraph(classPath, targetPath, targets, timeout),
  );
}
```  

And again cross-referencing the `getCallGraphGradle` lead us to `snyk-gradle-plugin` package and the following routine located at `snyk-gradle-plugin/lib/index.ts#`:  


```ts
// General implementation. The result type depends on the runtime type of `options`.
export async function inspect(
  root: string,
  targetFile: string,
  options?: Options,
): Promise<api.InspectResult> {
  debugLog(
    'Gradle inspect called with: ' +
      JSON.stringify({
        root,
        targetFile,
        allSubProjects: (options as any)?.allSubProjects,
        subProject: (options as any)?.subProject,
      }),
  );

...
let callGraph: CallGraph | undefined;
  const targetPath = path.join(root, targetFile);
  if (options.reachableVulns) {
    const command = getCommand(root, targetFile);
    debugLog(`getting call graph from path ${targetPath}`);
    callGraph = await javaCallGraphBuilder.getCallGraphGradle(
      path.dirname(targetPath),
      command,
    );
    debugLog('got call graph successfully');
  }
```  

`inspect` has an `InspectResult` callback for async call. By Following up through the code we finally reach here in `snyk/src/cli/command/monitor/index.ts`:  

```ts
// each plugin will be asked to scan once per path
      // some return single InspectResult & newer ones return Multi
      const inspectResult = await promiseOrCleanup(
        getDepsFromPlugin(path, {
          ...options,
          path,
          packageManager,
        }),
        spinner.clear(analyzingDepsSpinnerLabel),
      );
      analytics.add('pluginName', inspectResult.plugin.name);

```  

That `promiseOrCleanup` will handle the inspect function callbacks through the following definition:  

```ts
async function promiseOrCleanup<T>(
  p: Promise<T>,
  cleanup: (x?) => void,
): Promise<T> {
  return p.catch((error) => {
    cleanup();
    throw error;
  });
}
```  


#### What are the relevant tickets?

* [Zendesk ticket SC-8839](https://support.snyk.io/hc/en-us/requests/8839)
* [Zendesk ticket SC-7901](https://support.snyk.io/hc/en-us/requests/7901)

#### Screenshots


#### Additional questions
