### PR TITLE
fix: normalize init script path for all args

### DIFF
--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { fixtureDir } from '../common';
 import { test } from 'tap';
-import { inspect } from '../../lib';
+import { inspect, formatArgWithWhiteSpace } from '../../lib';
 import * as subProcess from '../../lib/sub-process';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
@@ -112,7 +112,7 @@ test('run inspect() with reachableVulns', async (t) => {
     javaCallGraphBuilderStub.calledWith(
       path.join('.', rootNoWrapper),
       'gradle',
-      path.join(rootNoWrapper, 'init.gradle'),
+      formatArgWithWhiteSpace(path.join(rootNoWrapper, 'init.gradle')), // arg should be normalized with quotes
     ),
     'call graph builder was called with the correct path and init file',
   );


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

Normalized init script path is sent for bot dependency discovery and call graph building.
Disables explicit propagation of the `init script` argument for dependency discovery.

This pull request was made in tandem with @pwnslinger . See: https://github.com/snyk/snyk-gradle-plugin/pull/170

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

Using different paths for init script and build.gradle files would create an error on the java call graph builder side if the parent directories differed.


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
