### PR TITLE
pass configattrs to javaCallGraphBuilder

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -125,11 +125,18 @@ export async function inspect(
       );
     }
 
+    let confAttrs: string | undefined;
+
+    if (options['configuration-attributes']) {
+      confAttrs = options['configuration-attributes'];
+    }
+
     debugLog(`getting call graph from path ${targetPath}`);
     callGraph = await javaCallGraphBuilder.getCallGraphGradle(
       path.dirname(targetPath),
       command,
       initScriptPath,
+      confAttrs,
     );
     debugLog('got call graph successfully');
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.28.0",
-    "@snyk/java-call-graph-builder": "1.20.0",
+    "@snyk/java-call-graph-builder": "1.22.0",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -99,10 +99,12 @@ test('run inspect() with reachableVulns', async (t) => {
     {
       reachableVulns: true,
       initScript: path.join(rootNoWrapper, 'init.gradle'),
+      'configuration-attributes':
+        'buildtype:release,usage:java-runtime,newdim:appA',
     },
   );
 
-  // test with init script param
+  // test with init script param/configuration attributes
   t.ok(
     javaCallGraphBuilderStub.calledTwice,
     'called to the call graph builder',
@@ -112,6 +114,7 @@ test('run inspect() with reachableVulns', async (t) => {
       path.join('.', rootNoWrapper),
       'gradle',
       formatArgWithWhiteSpace(path.join(rootNoWrapper, 'init.gradle')), // arg should be normalized with quotes
+      'buildtype:release,usage:java-runtime,newdim:appA',
     ),
     'call graph builder was called with the correct path and init file',
   );

--- a/test/system/reachability.test.ts
+++ b/test/system/reachability.test.ts
@@ -1,0 +1,119 @@
+import * as path from 'path';
+import { fixtureDir } from '../common';
+import { test } from 'tap';
+import { inspect, formatArgWithWhiteSpace } from '../../lib';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
+import { CallGraph } from '@snyk/cli-interface/legacy/common';
+
+const rootNoWrapper = fixtureDir('no wrapper');
+
+test('reachableVulns', async (t) => {
+  const gradleCallGraph = JSON.parse(
+    fs.readFileSync(
+      path.join(fixtureDir('call-graphs'), 'simple.json'),
+      'utf-8',
+    ),
+  );
+  const javaCallGraphBuilderStub = sinon
+    .stub(javaCallGraphBuilder, 'getCallGraphGradle')
+    .resolves(gradleCallGraph as CallGraph);
+
+  t.test('simple reachability scenario', async (t) => {
+    const result = await inspect(
+      '.',
+      path.join(rootNoWrapper, 'build.gradle'),
+      {
+        reachableVulns: true,
+      },
+    );
+
+    const pkgs = result.dependencyGraph.getDepPkgs();
+    const nodeIds: string[] = [];
+    Object.keys(pkgs).forEach((id) => {
+      nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
+    });
+
+    t.ok(
+      nodeIds.indexOf('com.android.tools:annotations@25.3.0') !== -1,
+      'correct version found',
+    );
+    t.ok(
+      javaCallGraphBuilderStub.calledOnce,
+      'called to the call graph builder',
+    );
+    t.ok(
+      javaCallGraphBuilderStub.calledWith(
+        path.join('.', rootNoWrapper),
+        'gradle',
+      ),
+      'call graph builder was called with the correct path',
+    );
+    t.same(gradleCallGraph, result.callGraph, 'returns expected callgraph');
+  });
+
+  t.test('with init script', async (t) => {
+    const resultWithInit = await inspect(
+      '.',
+      path.join(rootNoWrapper, 'build.gradle'),
+      {
+        reachableVulns: true,
+        initScript: path.join(rootNoWrapper, 'init.gradle'),
+      },
+    );
+
+    t.ok(
+      javaCallGraphBuilderStub.calledTwice,
+      'called to the call graph builder',
+    );
+    t.ok(
+      javaCallGraphBuilderStub.calledWith(
+        path.join('.', rootNoWrapper),
+        'gradle',
+        formatArgWithWhiteSpace(path.join(rootNoWrapper, 'init.gradle')), // arg should be normalized with quotes
+      ),
+      'call graph builder was called with the correct path and init file',
+    );
+    t.same(
+      gradleCallGraph,
+      resultWithInit.callGraph,
+      'returns expected callgraph',
+    );
+  });
+
+  t.test('with configuration attributes', async (t) => {
+    const resultWithConfigAttrs = await inspect(
+      '.',
+      path.join(rootNoWrapper, 'build.gradle'),
+      {
+        reachableVulns: true,
+        'configuration-attributes':
+          'buildtype:release,usage:java-runtime,newdim:appA',
+      },
+    );
+
+    t.ok(
+      javaCallGraphBuilderStub.calledThrice,
+      'called to the call graph builder',
+    );
+    t.ok(
+      javaCallGraphBuilderStub.calledWith(
+        path.join('.', rootNoWrapper),
+        'gradle',
+        undefined,
+        'buildtype:release,usage:java-runtime,newdim:appA',
+      ),
+      'call graph builder was called with the correct path and init file',
+    );
+    t.same(
+      gradleCallGraph,
+      resultWithConfigAttrs.callGraph,
+      'returns expected callgraph',
+    );
+  });
+
+  t.teardown(() => {
+    javaCallGraphBuilderStub.restore();
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

An error occurred while generating the call-graph. The main reason behind the error is the lack of a proper filtering on the build flavor that is explicitly specified in `configuration-attributes` gradle options.  

### Notes for the reviewer

#### PR for #9512 - filter classpath based on config attributes  
Snyk reachability produces a call-graph which simply contains call-hierarchy of different modules used in the code. java-call-graph-builder prints classpath of project (sub-project) using printClassPath task declared in [`init.gradle`](https://github.com/snyk/java-call-graph-builder/blob/master/bin/init.gradle). Generated classpath is passed to [`java-call-graph-generator.jar`](https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.5.0-jar-with-dependencies.jar) to generate call-graphs from classes. Here is the location this error happens:  

`
java -cp ./call-graph-generator/java-call-graph-generator.jar io.snyk.callgraph.app.App --application-classpath-file ./call-graph-generatorFqHSLD/callgraph-classpath --dirs-to-get-entrypoints ./varo-bank/mobile/android/varo-bank-android/app/build
`  

`callgraph-classpath` file contains the application classpath information as string of class pathes concatenated using colon. The command we passed in this scenario to the `snyk monitor` is the following:  

```
snyk monitor --all-sub-projects --file=app/build.gradle.kts --configuration-attributes=buildtype:release,usage:java-runtime,backend:prod --debug --insecure  --severity-threshold=medium --reachable -d >> log.txt 
```

Here is the `log.txt` contents: 

```bash
Error: 
Monitoring /Users/iosbuild/builds/u_N9zkzD/0/varo-bank/mobile/android/varo-bank-android...

ENOENT: no such file or directory, open '/Users/iosbuild/builds/u_N9zkzD/0/varo-bank/mobile/android/varo-bank-android/app/build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/prodPenTest/R.jar'
    at monitor (/usr/local/lib/node_modules/snyk/src/cli/commands/monitor/index.ts:297:9)
```  

After I closely looked at the classpath, I noticed that the recovered class paths includes all the other build flavors defined in the `build.gradle.kts`.  However, we explicitly mentioned `prodRelease` target in the configuration attributes passed to the monitor command. Now, it is obvious that `prodPenTest` classes are not found cause we did not compiled those at all. 

To fix this issue, I decided to propagate the `PconfAttr` variable through `getCallGraphGradle` as an argument to the `printClasspath` task. Next, if a certain build flavor specified, we can filter the ones that are not mentioned in `configuration-attributes`.  

This change only propgate the data to be handled by the java call graph builder - snyk/java-call-graph-builder#49. 

### More information

- https://snyksec.atlassian.net/browse/FLOW-689
- [Zendesk#9512](https://support.snyk.io/hc/en-us/requests/9512)
- snyk/java-call-graph-builder#49

### Screenshots

_Visuals that may help the reviewer_
