### PR TITLE
fix: prevent EBADF on macOS while installed with Yarn

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -398,9 +398,7 @@ async function getInjectedScriptPath(): Promise<{
   // Copying the injectable script into a temp file.
   try {
     const tmpInitGradle = tmp.fileSync({ postfix: '-init.gradle' });
-    fs.createReadStream(initGradleAsset).pipe(
-      fs.createWriteStream('', { fd: tmpInitGradle!.fd }),
-    );
+    fs.writeSync(tmpInitGradle.fd, fs.readFileSync(initGradleAsset));
     return {
       injectedScripPath: tmpInitGradle.name,
       cleanupCallback: tmpInitGradle.removeCallback,


### PR DESCRIPTION
Usage of filestream drops file descriptor, thus breaking Snyk CLI installed through Yarn running on macOS.