### PR TITLE
fix: specify gradle version in windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
   install_gradle_windows:
     description: Install gradle
     steps:
-      - run: choco install gradle
+      - run: choco install gradle --version=6.0
   install_sdkman:
     description: Install SDKMAN
     steps:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Following failing Windows tests in this PR: 
https://github.com/snyk/snyk-gradle-plugin/pull/175

Windows tests are using the latest Gradle version, because the chocolatey installation doesn't specify another version. 
The tests are using Gradle 7 which is not supported causing the tests to fail for Windows.
This change specifies a version.
