### PR TITLE
refactor: delete unnecessary duplicated test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,18 +174,6 @@ workflows:
 
     # UNIX tests
     - test-unix:
-        name: Unix Tests for Gradle=6 JDK=13 Node=12
-        context: nodejs-install
-        gradle_version: "6.0"
-        jdk_version: "13"
-        node_version: "12"
-        requires:
-          - Lint
-        filters:
-          branches:
-            ignore:
-              - master
-    - test-unix:
         name: Unix Tests for Gradle=6.0 JDK=13 Node=12
         context: nodejs-install
         gradle_version: "6.0"


### PR DESCRIPTION
Our circleci had the same testing step of Unix Tests for Gradle v6.0
JDK v13 and Node v12 written twice.