### PR TITLE
fix: scanning failure caused by missing proj-name

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -304,12 +304,11 @@ async function getAllDepsOneProject(
   const allSubProjectNames = allProjectDeps.allSubProjectNames;
 
   return subProject
-    ? getSubProject(root, subProject, allProjectDeps, allSubProjectNames)
-    : getRootProject(root, allProjectDeps, allSubProjectNames);
+    ? getSubProject(subProject, allProjectDeps, allSubProjectNames)
+    : getRootProject(allProjectDeps, allSubProjectNames);
 }
 
 function getSubProject(
-  root: string,
   subProject: string,
   allProjectDeps,
   allSubProjectNames: string[],
@@ -336,7 +335,6 @@ function getSubProject(
 }
 
 function getRootProject(
-  root: string,
   allProjectDeps,
   allSubProjectNames: string[],
 ): {
@@ -620,10 +618,15 @@ export async function processProjectsInExtractedJSON(
       continue;
     }
 
-    let projectName = path.basename(root);
+    const isValidRootDir = root !== null && root !== undefined;
+    const isSubProject = projectId !== defaultProject;
 
-    if (projectId !== defaultProject) {
-      projectName = `${path.basename(root)}/${projectId}`;
+    let projectName = isValidRootDir ? path.basename(root) : defaultProject;
+
+    if (isSubProject) {
+      projectName = isValidRootDir
+        ? `${path.basename(root)}/${projectId}`
+        : `${defaultProject}/${projectId}`;
     }
 
     extractedJSON.projects[projectId].depGraph = await buildGraph(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -192,7 +192,7 @@ export interface JsonDepsScriptResult {
   defaultProject: string;
   projects: ProjectsDict;
   allSubProjectNames: string[];
-  versionBuildInfo: VersionBuildInfo;
+  versionBuildInfo?: VersionBuildInfo;
 }
 
 interface SnykGraph {
@@ -206,8 +206,8 @@ interface ProjectsDict {
 }
 
 interface GradleProjectInfo {
-  depGraph: DepGraph;
-  snykGraph: { [name: string]: SnykGraph }; // snykGraph from gradle task
+  depGraph?: DepGraph;
+  snykGraph?: { [name: string]: SnykGraph }; // snykGraph from gradle task
   targetFile: string;
   projectVersion: string;
 }
@@ -302,43 +302,59 @@ async function getAllDepsOneProject(
 }> {
   const allProjectDeps = await getAllDeps(root, targetFile, options);
   const allSubProjectNames = allProjectDeps.allSubProjectNames;
-  if (subProject) {
-    const { depGraph, meta } = getDepsSubProject(subProject, allProjectDeps);
-    return {
-      depGraph,
-      allSubProjectNames,
-      gradleProjectName: meta.gradleProjectName,
-      versionBuildInfo: allProjectDeps.versionBuildInfo,
-    };
-  }
 
-  const { projects, defaultProject } = allProjectDeps;
-  const { depGraph } = projects[defaultProject];
-  return {
-    depGraph,
-    allSubProjectNames,
-    gradleProjectName: defaultProject,
-    versionBuildInfo: allProjectDeps.versionBuildInfo,
-  };
+  return subProject
+    ? getSubProject(root, subProject, allProjectDeps, allSubProjectNames)
+    : getRootProject(root, allProjectDeps, allSubProjectNames);
 }
 
-function getDepsSubProject(
+function getSubProject(
+  root: string,
   subProject: string,
-  allProjectDeps: JsonDepsScriptResult,
-): { depGraph: DepGraph; meta: any } {
-  const gradleProjectName = `${allProjectDeps.defaultProject}/${subProject}`;
-
+  allProjectDeps,
+  allSubProjectNames: string[],
+): {
+  depGraph: DepGraph;
+  allSubProjectNames: string[];
+  gradleProjectName: string;
+  versionBuildInfo: VersionBuildInfo;
+} {
   if (!allProjectDeps.projects || !allProjectDeps.projects[subProject]) {
     throw new MissingSubProjectError(subProject, Object.keys(allProjectDeps));
   }
 
-  const depGraph = allProjectDeps.projects[subProject].depGraph;
+  const { depGraph } = allProjectDeps.projects[subProject];
+  const { versionBuildInfo } = allProjectDeps;
+  const gradleProjectName = `${allProjectDeps.defaultProject}/${subProject}`;
 
   return {
     depGraph,
-    meta: {
-      gradleProjectName,
-    },
+    allSubProjectNames,
+    gradleProjectName,
+    versionBuildInfo,
+  };
+}
+
+function getRootProject(
+  root: string,
+  allProjectDeps,
+  allSubProjectNames: string[],
+): {
+  depGraph: DepGraph;
+  allSubProjectNames: string[];
+  gradleProjectName: string;
+  versionBuildInfo: VersionBuildInfo;
+} {
+  const { projects, defaultProject, versionBuildInfo } = allProjectDeps;
+  const { depGraph } = projects[defaultProject];
+
+  const gradleProjectName = defaultProject;
+
+  return {
+    depGraph,
+    allSubProjectNames,
+    gradleProjectName,
+    versionBuildInfo,
   };
 }
 
@@ -348,20 +364,23 @@ async function getAllDepsAllProjects(
   options: Options,
 ): Promise<ScannedProject[]> {
   const allProjectDeps = await getAllDeps(root, targetFile, options);
-  return Object.keys(allProjectDeps.projects).map((proj) => {
-    const defaultProject = allProjectDeps.defaultProject;
+  return Object.keys(allProjectDeps.projects).map((projectId) => {
+    const { defaultProject } = allProjectDeps;
     const gradleProjectName =
-      proj === defaultProject ? defaultProject : `${defaultProject}/${proj}`;
+      projectId === defaultProject
+        ? defaultProject
+        : `${defaultProject}/${projectId}`;
     return {
       targetFile: targetFileFilteredForCompatibility(
-        allProjectDeps.projects[proj].targetFile,
+        allProjectDeps.projects[projectId].targetFile,
       ),
       meta: {
         gradleProjectName,
+        projectName: gradleProjectName,
         versionBuildInfo: allProjectDeps.versionBuildInfo,
-        targetFile: allProjectDeps.projects[proj].targetFile,
+        targetFile: allProjectDeps.projects[projectId].targetFile,
       },
-      depGraph: allProjectDeps.projects[proj].depGraph,
+      depGraph: allProjectDeps.projects[projectId].depGraph,
     };
   });
 }
@@ -495,36 +514,17 @@ async function getAllDeps(
     if (cleanupCallback) {
       cleanupCallback();
     }
-    const extractedJson = extractJsonFromScriptOutput(stdoutText);
+    const extractedJSON = extractJsonFromScriptOutput(stdoutText);
     const jsonAttrsPretty = getGradleAttributesPretty(stdoutText);
     logger(
       `The following attributes and their possible values were found in your configurations: ${jsonAttrsPretty}`,
     );
     const versionBuildInfo = getVersionBuildInfo(gradleVersionOutput);
     if (versionBuildInfo) {
-      extractedJson.versionBuildInfo = versionBuildInfo;
+      extractedJSON.versionBuildInfo = versionBuildInfo;
     }
 
-    // processing snykGraph from gradle task to depGraph
-    for (const projectId in extractedJson.projects) {
-      const { snykGraph, projectVersion } = extractedJson.projects[projectId];
-
-      let projectName = path.basename(root);
-
-      if (projectId !== extractedJson.defaultProject) {
-        projectName = `${path.basename(root)}/${projectId}`;
-      }
-
-      extractedJson.projects[projectId].depGraph = await buildGraph(
-        snykGraph,
-        projectName,
-        projectVersion,
-      );
-      // this property usage ends here
-      delete extractedJson.projects[projectId].snykGraph;
-    }
-
-    return extractedJson;
+    return await processProjectsInExtractedJSON(root, extractedJSON);
   } catch (error0) {
     const error: Error = error0;
     const gradleErrorMarkers = /^\s*>\s.*$/;
@@ -606,6 +606,36 @@ ${blackOnYellow('===== DEBUG INFORMATION END =====')}
 ${chalk.red.bold(mainErrorMessage)}`;
     throw error;
   }
+}
+
+export async function processProjectsInExtractedJSON(
+  root: string,
+  extractedJSON: JsonDepsScriptResult,
+) {
+  for (const projectId in extractedJSON.projects) {
+    const { defaultProject } = extractedJSON;
+    const { snykGraph, projectVersion } = extractedJSON.projects[projectId];
+
+    if (!snykGraph) {
+      continue;
+    }
+
+    let projectName = path.basename(root);
+
+    if (projectId !== defaultProject) {
+      projectName = `${path.basename(root)}/${projectId}`;
+    }
+
+    extractedJSON.projects[projectId].depGraph = await buildGraph(
+      snykGraph,
+      projectName,
+      projectVersion,
+    );
+    // this property usage ends here
+    delete extractedJSON.projects[projectId].snykGraph;
+  }
+
+  return extractedJSON;
 }
 
 function toCamelCase(input: string) {

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -1,0 +1,59 @@
+import * as path from 'path';
+import { processProjectsInExtractedJSON } from '../../lib';
+
+describe('findProjectsInExtractedJSON', () => {
+  const fakeRootDir = path.join('dev', 'tardis-master');
+
+  it.each`
+    rootDir        | targetFile
+    ${fakeRootDir} | ${path.join(fakeRootDir, 'build.gradle')}
+  `(
+    'project with targetFile `$targetFile` have valid name when rootDir is `$rootDir`',
+    async ({ rootDir, targetFile }) => {
+      const jsonExtractedFromGradleStdout = {
+        defaultProject: 'tardis-master',
+        projects: {
+          'tardis-master': {
+            targetFile,
+            snykGraph: {
+              'com.tardis:b@1.0.13': {
+                name: 'com.tardis:b',
+                version: '1.0.13',
+                parentIds: ['com.tardis:a@1.5.0'],
+              },
+              'com.tardis:a@1.5.0': {
+                name: 'com.tardis:a',
+                version: '1.5.0',
+                parentIds: ['root-node'],
+              },
+            },
+            projectVersion: 'unspecified',
+          },
+        },
+        allSubProjectNames: [],
+      };
+
+      const {
+        defaultProject,
+        projects,
+        allSubProjectNames,
+      } = await processProjectsInExtractedJSON(
+        rootDir,
+        jsonExtractedFromGradleStdout,
+      );
+
+      expect(defaultProject).toEqual('tardis-master');
+      expect(projects['tardis-master']?.targetFile).toEqual(`${targetFile}`);
+      expect(projects['tardis-master'].depGraph.rootPkg).toEqual({
+        name: 'tardis-master',
+        version: 'unspecified',
+      });
+      expect(projects['tardis-master']?.depGraph.getPkgs()).toEqual([
+        { name: 'tardis-master', version: 'unspecified' },
+        { name: 'com.tardis:b', version: '1.0.13' },
+        { name: 'com.tardis:a', version: '1.5.0' },
+      ]);
+      expect(allSubProjectNames).toEqual([]);
+    },
+  );
+});

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -6,6 +6,8 @@ describe('findProjectsInExtractedJSON', () => {
 
   it.each`
     rootDir        | targetFile
+    ${null}        | ${'build.gradle'}
+    ${undefined}   | ${'build.gradle'}
     ${fakeRootDir} | ${path.join(fakeRootDir, 'build.gradle')}
   `(
     'project with targetFile `$targetFile` have valid name when rootDir is `$rootDir`',


### PR DESCRIPTION
**fix:**

- While processing snykGraphs from extractedJSON to depGraph,
  projectName is generated using the basename of the rootDir,  
  we were not handling it if by any chance it was null or undefined.
  Now that we handling it properly, we are preventing possible scanning errors.
  
**refactor:**

- Clarifying the purpose of few functions

- Moving the loop where we process all
  the existing projects in the extractedJSON from snykGraph to depGraph
  away from getAllDeps to its own function `processProjectsInExtractedJSON`,
  makes the projects process testable, enabling us of have more confidence on expected results

- Added a test for `processProjectsInExtractedJSON`
  
  