### PR TITLE
fix: prevent project name to be empty string

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -447,9 +447,9 @@ function getVersionBuildInfo(
   gradleVersionOutput: string,
 ): VersionBuildInfo | undefined {
   try {
-    const cleanedVersionOutput: string = cleanupVersionOutput(
-      gradleVersionOutput,
-    );
+    const cleanedVersionOutput: string =
+      cleanupVersionOutput(gradleVersionOutput);
+
     if (cleanedVersionOutput !== '') {
       const gradleOutputArray = cleanedVersionOutput.split(/\r\n|\r|\n/);
       // from first 3 new lines, we get the gradle version
@@ -463,9 +463,8 @@ function getVersionBuildInfo(
         .map((value) => value.split(/(.*): (.*)/))
         .forEach(
           (splitValue) =>
-            (metaBuildVersion[
-              toCamelCase(splitValue[1].trim())
-            ] = splitValue[2].trim()),
+            (metaBuildVersion[toCamelCase(splitValue[1].trim())] =
+              splitValue[2].trim()),
         );
       return {
         gradleVersion,
@@ -618,7 +617,8 @@ export async function processProjectsInExtractedJSON(
       continue;
     }
 
-    const isValidRootDir = root !== null && root !== undefined;
+    const invalidValues = [null, undefined, ''];
+    const isValidRootDir = invalidValues.indexOf(root) === -1;
     const isSubProject = projectId !== defaultProject;
 
     let projectName = isValidRootDir ? path.basename(root) : defaultProject;

--- a/test/functional/gradle-version-build-info.spec.ts
+++ b/test/functional/gradle-version-build-info.spec.ts
@@ -68,9 +68,8 @@ describe('Gradle Version Build Info', () => {
       'Ant:          Apache Ant(TM) version 1.9.13 compiled on July 10 2018\n' +
       'JVM:          9.0.4 (Oracle Corporation 9.0.4+11)\n' +
       'OS:           Mac OS X 10.15 x86_64';
-    const versionBuildInfo = testableMethods.getVersionBuildInfo(
-      expectedGradleOutput,
-    )!;
+    const versionBuildInfo =
+      testableMethods.getVersionBuildInfo(expectedGradleOutput)!;
 
     expect(versionBuildInfo).toEqual({
       gradleVersion: '5.4.1',

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -6,6 +6,7 @@ describe('findProjectsInExtractedJSON', () => {
 
   it.each`
     rootDir        | targetFile
+    ${''}          | ${'build.gradle'}
     ${null}        | ${'build.gradle'}
     ${undefined}   | ${'build.gradle'}
     ${fakeRootDir} | ${path.join(fakeRootDir, 'build.gradle')}
@@ -35,14 +36,11 @@ describe('findProjectsInExtractedJSON', () => {
         allSubProjectNames: [],
       };
 
-      const {
-        defaultProject,
-        projects,
-        allSubProjectNames,
-      } = await processProjectsInExtractedJSON(
-        rootDir,
-        jsonExtractedFromGradleStdout,
-      );
+      const { defaultProject, projects, allSubProjectNames } =
+        await processProjectsInExtractedJSON(
+          rootDir,
+          jsonExtractedFromGradleStdout,
+        );
 
       expect(defaultProject).toEqual('tardis-master');
       expect(projects['tardis-master']?.targetFile).toEqual(`${targetFile}`);


### PR DESCRIPTION
  Previously we were validating if the root cwd value being passed down
  from cli was either null or undefined, skipping empty string as an invalid case.
  With this pr we are adding empty string as an invalid case and avoid
  its usage as a gradle project name. What is the outcome? prevent
`Invalid DepGraph` error during scanning test/monitor phases