### PR TITLE
fix: update java-call-graph-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.28.0",
-    "@snyk/java-call-graph-builder": "1.23.0",
+    "@snyk/java-call-graph-builder": "1.23.1",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
https://github.com/snyk/java-call-graph-builder/pull/54

Update `java-call-graph-builder` to the version that uses version 3.7 of JSZip in order to mitigate a vulnerability