### PR TITLE
fix: use init.gradle copy in temp location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
     - release:
         name: Release
         context: nodejs-app-release
-        node_version: "10"
+        node_version: "14.17.6"
         filters:
           branches:
             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,18 @@ workflows:
 
     # UNIX tests
     - test-unix:
+        name: Unix Tests for Gradle=6.0 JDK=13 Node=14
+        context: nodejs-install
+        gradle_version: "6.0"
+        jdk_version: "13.0.2.j9-adpt"
+        node_version: "14.17.6"
+        requires:
+          - Lint
+        filters:
+          branches:
+            ignore:
+              - master
+    - test-unix:
         name: Unix Tests for Gradle=6.0 JDK=13 Node=12
         context: nodejs-install
         gradle_version: "6.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.28.0",
-    "@snyk/java-call-graph-builder": "1.23.1",
+    "@snyk/java-call-graph-builder": "1.23.2",
     "@types/debug": "^4.1.4",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
- [X] Ready for review

#### What does this PR do?

Bumps the version of `@snyk/java-call-graph-builder` to version `1.23.2` to include this fix: https://github.com/snyk/java-call-graph-builder/pull/57

Use temporary file copied to the local filesystem to ensure the separate process that reads `init.gradle` can find it in binary releases.

Also bumping the release to use node 14 because apparently that is required now by semantic release: https://app.circleci.com/pipelines/github/snyk/snyk-gradle-plugin/339/workflows/835b53ae-ae10-42f6-8e53-e9acbae2b43b/jobs/3534

I also added a test variant that uses node 14.