### PR TITLE
chore: upgrade jest and related deps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   ], // Remove when all tests are using Jest
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/test/manual/tsconfig.json',
+      tsconfig: '<rootDir>/test/manual/tsconfig.json',
     },
   },
   modulePathIgnorePatterns: ['<rootDir>/test/.*fixtures'],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^24.0.13",
+    "@types/jest": "^27.4.1",
     "@types/node": "^4.9.1",
     "@types/sinon": "^7.0.10",
     "@types/tmp": "0.2.0",
@@ -37,13 +37,13 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
-    "jest": "^24.8.0",
-    "prettier": "^2.0.2",
+    "jest": "^27.5.1",
+    "prettier": "^2.3.1",
     "sinon": "^2.4.1",
     "tap": "^12.6.1",
-    "ts-jest": "^24.0.2",
+    "ts-jest": "^27.1.4",
     "ts-node": "^8.3.0",
-    "typescript": "^3.9.2"
+    "typescript": "^4.2.0"
   },
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",

--- a/test/manual/android.spec.ts
+++ b/test/manual/android.spec.ts
@@ -2,9 +2,14 @@ import * as path from 'path';
 import { fixtureDir } from '../common';
 import { inspect } from '../../lib';
 
-// TODO fix me by applying env var ANDROID_SDK_ROOT (ANDROID_HOME was deprecated)
+// This test requires: env var ANDROID_SDK_ROOT (ANDROID_HOME was deprecated) and Android SDK installed on local machine
+// TODO: delete the test or emulate android sdk in CI/CD in order to run it properly
 describe.skip('android multi-variant build', () => {
-  expect(process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME).toBeTruthy();
+  test('process.env.ANDROID_SDK_ROOT is set', () => {
+    expect(
+      process.env.ANDROID_SDK_ROOT || process.env.ANDROID_HOME,
+    ).toBeTruthy();
+  });
 
   test('we cannot inspect naively', async () => {
     await expect(


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules

#### What does this PR do?
- Upgrades versions of: jest, ts-jest and @types/jest

- In android.spec.ts everything in the describe block should be skipped on default. With the older versions it was. Now, the describe.skip() means tests will be skipped but [the describe block will still be run](https://jestjs.io/docs/api#describeskipname-fn) and it will fail if the environment variable is not set. Therefore, this adds a separate test block to check if the env var exists.

#### How should this be manually tested?
Run `npm run test-manual && npm run test-functional`
(`npm run test` will also run tap test which aren't relevant here)
