### PR TITLE
chore: update PR review template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
-- [ ] Ready for review
-- [ ] Follows CONTRIBUTING rules
-- [ ] Reviewed by Snyk internal team
+- [ ] Tests written and linted
+- [ ] Documentation written
+- [ ] Commit history is tidy
 
-#### What does this PR do?
+### What this does
 
+_Explain why this PR exists_
 
-#### Where should the reviewer start?
+### Notes for the reviewer
 
+_Instructions on how to run this locally, background context, what to review, questions…_
 
 #### How should this be manually tested?
 
+### More information
 
-#### Any background context you want to provide?
+- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
 
+### Screenshots
 
-#### What are the relevant tickets?
-
-
-#### Screenshots
-
+_Visuals that may help the reviewer_
 
 #### Additional questions


### PR DESCRIPTION
#### What does this PR do?
This changes the PR template:
The above 3 points to tick:

> - [ ] Ready for review
> - [ ] Follows CONTRIBUTING rules
> - [ ] Reviewed by Snyk internal team

 are redundant as it's all done by Github - a PR is ready for a review when it's not marked a draft, following contributing rules is done by signing the licence, reviews are assigned automatically. We could use the template we have in other repos that has more useful info.


