### PR TITLE
fix: relax multiple jsondeps line error

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -240,10 +240,14 @@ function extractJsonFromScriptOutput(stdoutText: string): JsonDepsScriptResult {
   lines.forEach((l) => {
     if (/^JSONDEPS /.test(l)) {
       if (jsonLine !== null) {
-        throw new Error(
-          'More than one line with "JSONDEPS " prefix was returned; full output:\n' +
-            stdoutText,
-        );
+        debugLog('More than one line with "JSONDEPS " prefix was returned;');
+        debugLog('First line: ' + jsonLine);
+        debugLog('Current line:' + l.substr(9));
+        // TODO (@tardis): the init.gradle should protect against this using 'snykDepsConfExecuted' flag
+        // the longer term fix here is to make multiple snyk graph outputs impossible by interacting with
+        // Gradle API in a more consistent way.
+        // For now, assume the first JSONDEPS found was correct
+        return;
       }
       jsonLine = l.substr(9);
     }

--- a/test/functional/gradle-extract-stdout.spec.ts
+++ b/test/functional/gradle-extract-stdout.spec.ts
@@ -21,14 +21,10 @@ JSONDEPS {"hello": "world"}
     }
   });
 
-  it('extractJsonFromScriptOutput throws on multiple JSONDEPS', () => {
+  it('extractJsonFromScriptOutput returns first on multiple JSONDEPS', () => {
     const output = 'JSONDEPS {"hello": "world"}\nJSONDEPS ["one more thing"]';
-    try {
-      testableMethods.extractJsonFromScriptOutput(output);
-    } catch ({ message }) {
-      const errorMessage = `More than one line with "JSONDEPS " prefix was returned; full output:\n${output}`;
-      expect(message).toBe(errorMessage);
-    }
+    const result = testableMethods.extractJsonFromScriptOutput(output);
+    expect(result).toEqual({ hello: 'world' });
   });
 
   it('getGradleAttributesPretty returns undefined when throws', async () => {


### PR DESCRIPTION


- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does

When we see multiple JSONDEPS lines, assume the first line was correct and do not throw an exception.
We have seen in some more sophisticated project setups this become an issue.
There is a flag 'snykDepsConfExecuted' in the init.gradle that should protect against this, but doesn't always.

There is more work todo in order to remove this assumption, but we need to work on a better method of communicating with the Gradle API from the init.gradle script that is guaranteed to produce one consistent graph object.
