### PR TITLE
feat: add debug logging for configs with failing resolvedConfiguration

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -181,6 +181,7 @@ def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
             resolvable.add(it)
         } catch (Exception ex) {
             // Swallow the error
+            debugLog("Skipping config ${it.name} due to resolvedConfiguration error.")
         }
     })
     debugLog("resolvableConfigs=$resolvable")


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy

### What this does
Adds a debug log to let us know when configurations will be ignored due to a failed `resolvedConfiguration` method call. This can occur when a config doesn't have lock state and strict lock mode is turned on.