### PR TITLE
refactor: use groovy types

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -58,7 +58,7 @@ import org.gradle.util.GradleVersion
 class SnykGraph {
 
     def nodes
-    def rootId
+    String rootId
     SnykGraph(rootId) {
         this.nodes = [:]
         this.rootId = rootId
@@ -74,12 +74,12 @@ class SnykGraph {
         if (!value) {
             return
         }
-        def vertex = ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
+        Map vertex = ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
         this.nodes.put(key, vertex)
         return vertex
     }
 
-    def setEdge(parentId, childId) {
+    void setEdge(parentId, childId) {
         if (!parentId || !childId || parentId == childId) {
             return
         }
@@ -99,7 +99,7 @@ class SnykGraph {
 
 }
 
-def loadGraph(Iterable deps, SnykGraph graph, parentId, currentChain) {
+def loadGraph(Iterable deps, SnykGraph graph, String parentId, HashSet currentChain) {
     deps.each { dep ->
             dep.each { d ->
                 String childId = "${d.moduleGroup}:${d.moduleName}@${d.moduleVersion}"
@@ -119,7 +119,7 @@ def loadGraph(Iterable deps, SnykGraph graph, parentId, currentChain) {
 }
 
 def getSnykGraph(Iterable deps) {
-    def rootId = 'root-node'
+    String rootId = 'root-node'
     def graph = new SnykGraph(rootId)
     def currentChain = new HashSet()
     loadGraph(deps, graph, rootId, currentChain)
@@ -129,7 +129,7 @@ def getSnykGraph(Iterable deps) {
 
 void debugLog(msg) {
     String debug = System.getenv('DEBUG') ?: ''
-    if (debug.length() > 0) {
+    if (debug) {
         println("SNYKECHO $msg")
     }
 }
@@ -172,7 +172,7 @@ def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
     // We are looking for a configuration that `canBeResolved`, because it's a configuration for which 
     // we can compute a dependency graph and that contains all the necessary information for resolution to happen.
     // See Gradle docs: https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs
-    def resolvable = []
+    List resolvable = []
     matching.each({ it ->
         if (!it.canBeResolved) { return }
         try {
@@ -195,7 +195,7 @@ allprojects { currProj ->
     debugLog("Current project: $currProj.name")
     task snykResolvedDepsJson {
         def onlyProj = project.hasProperty('onlySubProject') ? onlySubProject : null
-        def confNameFilter = (project.hasProperty('configuration')
+        String confNameFilter = (project.hasProperty('configuration')
             ? Pattern.compile(configuration, Pattern.CASE_INSENSITIVE)
             : /.*/
         )
@@ -272,9 +272,9 @@ allprojects { currProj ->
                 debugLog("processing project: name=$proj.name; path=$proj.path")
 
                 def resolvableConfigs = findProjectConfigs(proj, confNameFilter, confAttrSpec)
-                def resolvedConfigs = []
+                List resolvedConfigs = []
                 resolvableConfigs.each({ config ->
-                    def resConf = config.resolvedConfiguration
+                    def resConf = config?.resolvedConfiguration
                     debugLog("config `$config.name' resolution has errors: ${resConf.hasError()}")
                     if (!resConf.hasError()) {
                         resolvedConfigs.add(resConf)
@@ -292,7 +292,7 @@ allprojects { currProj ->
                 
                 debugLog('converting gradle graph to snyk-graph format')
                 def projGraph = getSnykGraph(nonemptyFirstLevelDeps)
-                def projKey = proj.name
+                String projKey = proj.name
                 if (projects.get(projKey)) {
                     debugLog("The deps dict already has a project with key `$projKey'; using the full path")
                     projKey = proj.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -35,10 +35,10 @@ import org.gradle.util.GradleVersion
 
 // interface JsonDepsScriptResult {
 //   defaultProject: string;
-//   projects: ProjectsDict;
+//   projects: Projects;
 //   allSubProjectNames: string[];
 // }
-// interface ProjectsDict {
+// interface Projects {
 //   [project: string]: GradleProjectInfo;
 // }
 
@@ -102,9 +102,9 @@ class SnykGraph {
 def loadGraph(Iterable deps, SnykGraph graph, parentId, currentChain) {
     deps.each { dep ->
             dep.each { d ->
-                def childId = "${d.moduleGroup}:${d.moduleName}@${d.moduleVersion}"
+                String childId = "${d.moduleGroup}:${d.moduleName}@${d.moduleVersion}"
                 if (!graph.nodes.get(childId)) {
-                    def childDependency = ['name': "${d.moduleGroup}:${d.moduleName}", 'version': d.moduleVersion]
+                    Map childDependency = ['name': "${d.moduleGroup}:${d.moduleName}", 'version': d.moduleVersion]
                     graph.setNode(childId, childDependency)
                 }
                 //  In Gradle 2, there can be several instances of the same dependency present at each level,
@@ -127,25 +127,25 @@ def getSnykGraph(Iterable deps) {
     return graph.nodes
 }
 
-def debugLog(msg) {
-    def debug = System.getenv('DEBUG') ?: ''
+void debugLog(msg) {
+    String debug = System.getenv('DEBUG') ?: ''
     if (debug.length() > 0) {
         println("SNYKECHO $msg")
     }
 }
 
-def matchesAttributeFilter(conf, confAttrSpec) {
+Boolean matchesAttributeFilter(conf, confAttrSpec) {
     if (!conf.hasProperty('attributes')) {
         // Gradle before version 3 does not support attributes
         return true
     }
-    def matches = true
+    Boolean matches = true
     def attrs = conf.attributes
     attrs.keySet().each({ attr ->
-        def attrValueAsString = attrs.getAttribute(attr).toString().toLowerCase()
+        String attrValue = attrs.getAttribute(attr).toString().toLowerCase()
         confAttrSpec.each({ keyValueFilter ->
             // attr.name is a class name, e.g. com.android.build.api.attributes.BuildTypeAttr
-            if (attr.name.toLowerCase().contains(keyValueFilter[0]) && attrValueAsString != keyValueFilter[1]) {
+            if (attr.name.toLowerCase().contains(keyValueFilter[0]) && attrValue != keyValueFilter[1]) {
                 matches = false
             }
         })
@@ -190,7 +190,7 @@ def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
 // We are attaching this task to every project, as this is the only reliable way to run it
 // when we start with a subproject build.gradle. As a consequence, we need to make sure we
 // only ever run it once, for the "starting" project.
-def snykDepsConfExecuted = false
+Boolean snykDepsConfExecuted = false
 allprojects { currProj ->
     debugLog("Current project: $currProj.name")
     task snykResolvedDepsJson {
@@ -238,9 +238,9 @@ allprojects { currProj ->
                     }
             }
 
-            def defaultProjectName = task.project.name
-            def allSubProjectNames = []
-            def seenSubprojects = [:]
+            String defaultProjectName = task.project.name
+            List allSubProjectNames = []
+            Map seenSubprojects = [:]
             allprojects
                 .findAll({ it.name != defaultProjectName })
                 .each({
@@ -259,7 +259,7 @@ allprojects { currProj ->
                 (onlyProj == '.' && it.name == defaultProjectName) ||
                 it.name == onlyProj
             }
-            def projectsDict = [:]
+            Map projects = [:]
 
             debugLog("defaultProjectName=$defaultProjectName; allSubProjectNames=$allSubProjectNames")
 
@@ -293,7 +293,7 @@ allprojects { currProj ->
                 debugLog('converting gradle graph to snyk-graph format')
                 def projGraph = getSnykGraph(nonemptyFirstLevelDeps)
                 def projKey = proj.name
-                if (projectsDict.get(projKey)) {
+                if (projects.get(projKey)) {
                     debugLog("The deps dict already has a project with key `$projKey'; using the full path")
                     projKey = proj.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
                     if (projKey == "") {
@@ -301,16 +301,16 @@ allprojects { currProj ->
                         projKey = defaultProjectName
                     }
                 }
-                projectsDict[projKey] = [
+                projects[projKey] = [
                     'targetFile': findProject(proj.path).buildFile.toString(),
                     'snykGraph': projGraph,
                     'projectVersion': proj.version.toString()
                 ]
             }
 
-            def result = [
+            Map result = [
                 'defaultProject': defaultProjectName,
-                'projects': projectsDict,
+                'projects': projects,
                 'allSubProjectNames': allSubProjectNames
             ]
             def jsonDeps = JsonOutput.toJson(result)


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written
- [ ] Commit history is tidy

### What this does
Instead of optionally typing Groovy using `def`, use explicit static types 