### PR TITLE
fix: subproject with same name as root

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -246,7 +246,7 @@ allprojects { currProj ->
             def allSubProjectNames = []
             def seenSubprojects = [:]
             allprojects
-                .findAll({ it.name != defaultProjectName })
+                .findAll({ it.path != task.project.path })
                 .each({
                     def projKey = it.name
                     if (seenSubprojects.get(projKey)) {

--- a/test/fixtures/subproject-with-same-name-as-root/README.md
+++ b/test/fixtures/subproject-with-same-name-as-root/README.md
@@ -1,0 +1,14 @@
+# Multi-module project with a nested subproject with the same name as root
+
+The following dep-tree was generated using the command: `./gradlew dependencies`
+
+```s
++--- com.google.guava:guava:30.1.1-jre
+|    +--- com.google.guava:failureaccess:1.0.1
+|    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- org.checkerframework:checker-qual:3.8.0
+|    +--- com.google.errorprone:error_prone_annotations:2.5.1
+|    \--- com.google.j2objc:j2objc-annotations:1.3
+\--- joda-time:joda-time:2.2
+```

--- a/test/fixtures/subproject-with-same-name-as-root/build.gradle
+++ b/test/fixtures/subproject-with-same-name-as-root/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'application'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.google.guava:guava:30.1.1-jre'
+    implementation "joda-time:joda-time:2.2"
+}

--- a/test/fixtures/subproject-with-same-name-as-root/greeter/subproject-with-same-name-as-root/build.gradle
+++ b/test/fixtures/subproject-with-same-name-as-root/greeter/subproject-with-same-name-as-root/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'application'
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {   
+    implementation "org.apache.struts:struts2-spring-plugin:2.3.1"
+}

--- a/test/fixtures/subproject-with-same-name-as-root/lib/build.gradle
+++ b/test/fixtures/subproject-with-same-name-as-root/lib/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'org.apache.commons:commons-lang3:3.12.0'
+}

--- a/test/fixtures/subproject-with-same-name-as-root/settings.gradle
+++ b/test/fixtures/subproject-with-same-name-as-root/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'subproject-with-same-name-as-root'
+include ':lib', ':greeter', ':greeter:subproject-with-same-name-as-root'


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does

Changes the way subprojects are filtered, instead of checking if the subproject has the same name as the root project, check if it has the same path. This helps with when a project contains a nested subproject with the same name as root. Do not override one with the other.