### PR TITLE
refactor: treat --sub-project option like --file option, as defaultProj

### DIFF
--- a/lib/errors/missing-sub-project-error.ts
+++ b/lib/errors/missing-sub-project-error.ts
@@ -1,6 +1,6 @@
 export class MissingSubProjectError extends Error {
   public name = 'MissingSubProjectError';
-  public targetProject: string;
+  public subProject: string;
   public allProjects: string[];
 
   constructor(subProject: string, allSubProjectNames: string[]) {

--- a/lib/errors/missing-sub-project-error.ts
+++ b/lib/errors/missing-sub-project-error.ts
@@ -1,6 +1,6 @@
 export class MissingSubProjectError extends Error {
   public name = 'MissingSubProjectError';
-  public subProject: string;
+  public targetProject: string;
   public allProjects: string[];
 
   constructor(subProject: string, allSubProjectNames: string[]) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -108,7 +108,6 @@ export async function inspect(
         subProject: (options as any)?.subProject,
       }),
   );
-
   if (!options) {
     options = { dev: false };
   }
@@ -166,7 +165,7 @@ export async function inspect(
 
 // See the comment for DepRoot.targetFile
 // Note: for Gradle, we are not returning the name unless it's a .kts file.
-// This is a workaround for a project naming problem happening in Registry
+// TODO: This is a workaround for a project naming problem happening in Registry
 // (legacy projects are named without "build.gradle" attached to them).
 // See ticket BST-529 re permanent solution.
 function targetFileFilteredForCompatibility(
@@ -179,6 +178,7 @@ function targetFileFilteredForCompatibility(
 
 export interface JsonDepsScriptResult {
   defaultProject: string;
+  defaultProjectKey: string;
   projects: ProjectsDict;
   allSubProjectNames: string[];
   versionBuildInfo?: VersionBuildInfo;

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -35,6 +35,7 @@ import org.gradle.util.GradleVersion
 
 // interface JsonDepsScriptResult {
 //   defaultProject: string;
+//   defaultProjectKey: string;
 //   projects: ProjectsDict;
 //   allSubProjectNames: string[];
 // }
@@ -300,8 +301,11 @@ allprojects { Project currProj ->
                         })
                     }
             }
-
-            def defaultProjectName = task.project.name
+            // use name of the target project: name of module indicated by --sub-project or --file or default root project
+            String defaultProjectName = onlyProj && onlyProj != "." ? onlyProj : task.project.name  
+            debugLog("project path: $task.project.path, project name: $task.project.name, subproj: $onlyProj")
+            // if project is root use default name, otherwise, use the path formatted to be e.g. greeter/subproj or subproj
+            String defaultProjectKey = task.project.path == ':' ? defaultProjectName : formatPath(task.project.path)
             def allSubProjectNames = []
             def seenSubprojects = [:]
             allprojects
@@ -311,7 +315,7 @@ allprojects { Project currProj ->
                     if (seenSubprojects.get(projKey)) {
                         projKey = formatPath(it.path)
                         if (projKey == "") {
-                            projKey = defaultProjectName
+                            projKey = defaultProjectKey
                         }
                     }
                     allSubProjectNames.add(projKey)
@@ -372,6 +376,7 @@ allprojects { Project currProj ->
 
             def result = [
                 'defaultProject': defaultProjectName,
+                'defaultProjectKey': defaultProjectKey,
                 'projects': projectsDict,
                 'allSubProjectNames': allSubProjectNames
             ]

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -15,6 +15,7 @@ describe('findProjectsInExtractedJSON', () => {
     async ({ rootDir, targetFile }) => {
       const jsonExtractedFromGradleStdout = {
         defaultProject: 'tardis-master',
+        defaultProjectKey: 'dev/tardis-master',
         projects: {
           'tardis-master': {
             targetFile,


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written
- [ ] Commit history is tidy

### What this does

* --file and --sub-project have the same purpose, when used from a root directory they allow to analyze only one target project, however currently we treat them differently
* this should prepare ground for changes in project identification - using path (unique value) instead of name as we sometimes see duplicates of names in multi module builds   

### Notes for the reviewer
The change does something to the rootPkg.name value, therefore there are some commented lines in `multi-project.test.ts`. The test doesn't look reliable - the results for the test with `--sub-project` set where the `--sub-project` value needs trimming should be the same as for when it's not trimmed. 
Where is rootPkg used and can we change it?  

Don't think this is how we should set the projectName because this is not a reliable way to determine if project is a subproject (in case there are duplicates) and I am not sure why we want this format of name (a path from root?) - does this matter for anything?
 
```
    const isSubProject = projectId !== defaultProject;

    let projectName = isValidRootDir ? path.basename(root) : defaultProject;

    if (isSubProject) {
      projectName = isValidRootDir
        ? `${path.basename(root)}/${projectId}`
        : `${defaultProject}/${projectId}`;
    } 
```