### PR TITLE
fix: track duplicate module names

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -191,6 +191,14 @@ def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
     return resolvable
 }
 
+String formatPath(path) {
+    return path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
+}
+
+Boolean isRootPath(path) {
+    return path == rootProject.path
+}
+
 // We are attaching this task to every project, as this is the only reliable way to run it
 // when we start with a subproject build.gradle. As a consequence, we need to make sure we
 // only ever run it once, for the "starting" project.
@@ -242,22 +250,18 @@ allprojects { currProj ->
                     }
             }
 
-            def defaultProjectName = task.project.name
+            String defaultProjectName = task.project.name
+            String defaultProjectKey = isRootPath(task.project.path) ? defaultProjectName : formatPath(task.project.path) 
+            debugLog("defaultProjectName: $defaultProjectName, defaultProjectKey: $defaultProjectKey")
             def allSubProjectNames = []
-            def seenSubprojects = [:]
+            // everything that isn't root is considered a sub-project
             allprojects
-                .findAll({ it.path != task.project.path })
+                .findAll({ !isRootPath(it.path) })
                 .each({
-                    def projKey = it.name
-                    if (seenSubprojects.get(projKey)) {
-                        projKey = it.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
-                        if (projKey == "") {
-                            projKey = defaultProjectName
-                        }
-                    }
+                    String projKey = formatPath(it.path)
                     allSubProjectNames.add(projKey)
-                    seenSubprojects[projKey] = true
                 })
+            // TODO it.name is the Gradle task snykResolvedDepsJson
             def shouldScanProject = {
                 onlyProj == null ||
                 (onlyProj == '.' && it.name == defaultProjectName) ||
@@ -295,15 +299,7 @@ allprojects { currProj ->
                 
                 debugLog('converting gradle graph to snyk-graph format')
                 def projGraph = getSnykGraph(nonemptyFirstLevelDeps)
-                def projKey = proj.name
-                if (projectsDict.get(projKey)) {
-                    debugLog("The deps dict already has a project with key `$projKey'; using the full path")
-                    projKey = proj.path.replace(':', '/').replaceAll(~/(^\/+?)|(\/+$)/, '')
-                    if (projKey == "") {
-                        debugLog("project path is empty (proj.path=$proj.path)! will use defaultProjectName=$defaultProjectName")
-                        projKey = defaultProjectName
-                    }
-                }
+                String projKey = isRootPath(proj.path) ? proj.name : formatPath(proj.path)
                 projectsDict[projKey] = [
                     'targetFile': findProject(proj.path).buildFile.toString(),
                     'snykGraph': projGraph,
@@ -313,6 +309,7 @@ allprojects { currProj ->
 
             def result = [
                 'defaultProject': defaultProjectName,
+                'defaultProjectKey': defaultProjectKey,
                 'projects': projectsDict,
                 'allSubProjectNames': allSubProjectNames
             ]

--- a/test/fixtures/subprojects-same-name/README.md
+++ b/test/fixtures/subprojects-same-name/README.md
@@ -1,0 +1,3 @@
+# Multi-module project with a nested subproject with the same name as a subproject in root path
+
+:greeter:subproj is dependent on :subproj

--- a/test/fixtures/subprojects-same-name/build.gradle
+++ b/test/fixtures/subprojects-same-name/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'application'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "joda-time:joda-time:2.2"
+}

--- a/test/fixtures/subprojects-same-name/greeter/subproj/build.gradle
+++ b/test/fixtures/subprojects-same-name/greeter/subproj/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'application'
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {   
+    implementation "org.apache.struts:struts2-spring-plugin:2.3.1"
+    implementation project(":subproj")
+}

--- a/test/fixtures/subprojects-same-name/settings.gradle
+++ b/test/fixtures/subprojects-same-name/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'subprojects-same-name'
+include ':subproj', ':greeter', ':greeter:subproj'

--- a/test/fixtures/subprojects-same-name/subproj/build.gradle
+++ b/test/fixtures/subprojects-same-name/subproj/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+     implementation 'com.google.guava:guava:30.1.1-jre'
+}

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -15,6 +15,7 @@ describe('findProjectsInExtractedJSON', () => {
     async ({ rootDir, targetFile }) => {
       const jsonExtractedFromGradleStdout = {
         defaultProject: 'tardis-master',
+        defaultProjectKey: 'tardis-master',
         projects: {
           'tardis-master': {
             targetFile,

--- a/test/system/failure-states.test.ts
+++ b/test/system/failure-states.test.ts
@@ -35,7 +35,7 @@ test('multi-project: error on missing sub-project', async () => {
       options,
     ),
   ).rejects.toThrowError(
-    /Specified sub-project not found: "non-existent". Found these projects: defaultProject, projects/,
+    /Specified sub-project not found: "non-existent". Found these projects: subproj/,
   );
 });
 

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -506,3 +506,26 @@ test('multi-project: correct deps for subprojects with the same name as root', a
     'org.apache.struts:struts2-spring-plugin@2.3.1',
   );
 });
+
+test.only('multi-project, explicitly targeting a subproject build file with the same name as another module in root', async () => {
+  const result = await inspect(
+    '.',
+    path.join(
+      fixtureDir('subprojects-with-same-name-dependent'),
+      'greeter',
+      'subproj',
+      'build.gradle',
+    ),
+  );
+  const projectDeps = {};
+  for (const p of result.scannedProjects) {
+    projectDeps[p.meta.projectName] = p.depGraph
+      .getDepPkgs()
+      .map((d) => `${d.name}@${d.version}`);
+  }
+
+  const rootGraph = projectDeps['subproj'];
+  expect(rootGraph.length).toBe(44); //to be checked
+  expect(rootGraph).toContain('org.apache.struts:struts2-spring-plugin:2.3.1'); // this project's dep
+  expect(rootGraph).toContain('com.google.guava:guava:30.1.1-jre'); // dep of the subproj module
+});


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
- Change the way we identify modules in multi-module projects. We have been using names of modules but in some projects these are duplicated. Use relative path instead. 
- Treat everything that isn't root as submodule.


