### PR TITLE
fix: display more accurate error message

### DIFF
--- a/lib/errors/missing-sub-project-error.ts
+++ b/lib/errors/missing-sub-project-error.ts
@@ -3,13 +3,13 @@ export class MissingSubProjectError extends Error {
   public subProject: string;
   public allProjects: string[];
 
-  constructor(subProject: string, allProjects: string[]) {
-    super(
-      `Specified sub-project not found: "${subProject}". ` +
-        `Found these projects: ${allProjects.join(', ')}`,
-    );
+  constructor(subProject: string, allSubProjectNames: string[]) {
+    const msg = !allSubProjectNames.length
+      ? 'No projects found.'
+      : `Found these projects: ${allSubProjectNames}`;
+    super(`Specified sub-project not found: "${subProject}". ` + msg);
     this.subProject = subProject;
-    this.allProjects = allProjects;
+    this.allProjects = allSubProjectNames;
     Error.captureStackTrace(this, MissingSubProjectError);
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -304,7 +304,7 @@ function getTargetProject(
   let gradleProjectName = defaultProject;
   if (subProject) {
     if (!allProjectDeps.projects || !allProjectDeps.projects[subProject]) {
-      throw new MissingSubProjectError(subProject, Object.keys(allProjectDeps));
+      throw new MissingSubProjectError(subProject, allSubProjectNames);
     }
     gradleProjectName = `${allProjectDeps.defaultProject}/${subProject}`;
   }

--- a/test/system/failure-states.test.ts
+++ b/test/system/failure-states.test.ts
@@ -35,7 +35,7 @@ test('multi-project: error on missing sub-project', async () => {
       options,
     ),
   ).rejects.toThrowError(
-    /Specified sub-project not found: "non-existent". Found these projects: defaultProject, projects/,
+    /Specified sub-project not found: "non-existent". Found these projects: subproj/,
   );
 });
 


### PR DESCRIPTION
### What this does
Currently in the missing sub project error message we display names of variables instead of actual names of subprojects. Display names of existing subprojects or if no projects are resolved display a relevant message.
