### PR TITLE
fix: don't fail if matching config doesn't exist

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -212,9 +212,6 @@ def matchesAttributeFilter(conf, confAttrSpec) {
 
 def findMatchingConfigs(confs, confNameFilter, confAttrSpec) {
     def matching = confs.findAll({ it.name =~ confNameFilter })
-    if (matching.isEmpty() && !confs.isEmpty()) {
-        throw new RuntimeException('Matching configurations ' + confNameFilter + ' were not found')  
-    }
     if (confAttrSpec == null) {
         // We don't have an attribute spec to match
         return matching
@@ -474,7 +471,7 @@ allprojects { Project currProj ->
                         debugLog("first level module dependencies for config `$config.name': $resConf.firstLevelModuleDependencies")
                     }
                 })
-                if (resolvedConfigs.isEmpty() && !resolvableConfigs.isEmpty()) {
+                if (!resolvableConfigs.isEmpty() && resolvedConfigs.isEmpty()) {
                     throw new RuntimeException('Configurations: ' + resolvableConfigs.collect { it.name } +
                             ' for project ' + proj + ' could not be resolved.')
                 }

--- a/test/system/failure-states.test.ts
+++ b/test/system/failure-states.test.ts
@@ -38,11 +38,3 @@ test('multi-project: error on missing sub-project', async () => {
     /Specified sub-project not found: "non-existent". Found these projects: subproj/,
   );
 });
-
-test('error when requested configurations are not found in the project', async () => {
-  await expect(
-    inspect('.', path.join(rootNoWrapper, 'build.gradle'), {
-      'configuration-matching': 'nonExistentConfig',
-    }),
-  ).rejects.toThrowError(/Matching configurations/);
-});

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -413,6 +413,28 @@ test('multi-project: do not exclude subprojects with the same name as root', asy
   ]);
 });
 
+test('multi-project: consider matching config if it is available only in one targetted subproject', async () => {
+  // only greeter module has config 'downloadJar'
+  const options = {
+    'configuration-matching': 'downloadJar',
+    subProject: 'greeter',
+  };
+  const result = await inspect(
+    '.',
+    path.join(fixtureDir('multi-project-different-names'), 'build.gradle'),
+    options,
+  );
+  const pkgs = result.dependencyGraph.getDepPkgs();
+  const nodeIds: string[] = [];
+  Object.keys(pkgs).forEach((id) => {
+    nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
+  });
+
+  expect(
+    nodeIds.indexOf('org.apache.commons:commons-collections4@4.4'),
+  ).toBeGreaterThanOrEqual(0);
+});
+
 test('multi-project: use flat naming when subprojects have different names', async () => {
   const result = await inspect(
     '.',


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
fix #229 
Don't throw error if requested config (passed with --configuration-matching) doesn't exist on a project . 
