### PR TITLE
fix: rest package path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ workflows:
       - lint:
           name: Lint
           context: nodejs-install
-          node_version: '10'
+          node_version: '12'
       - test-unix:
           name: Test OS=Unix Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -13,7 +13,8 @@ export async function getMavenPackageInfo(
 ): Promise<string> {
   const { res, body } = await snykHttpClient({
     method: 'get',
-    path: `/rest/packages`,
+    // base URL defaults to SNYK_API_REST_URL="https://api.snyk.io/rest"
+    path: `/packages`,
     qs: {
       version: PACKAGE_SEARCH_VERSION,
       /* eslint-disable @typescript-eslint/camelcase */

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist-test",
     "pretty": true,
-    "target": "es2017",
-    "lib": ["es2017"],
+    "target": "es2019",
+    "lib": ["es2019", "dom"],
     "module": "commonjs",
     "allowJs": false,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,16 @@
 {
   "compilerOptions": {
-      "outDir": "./dist",
-      "pretty": true,
-      "target": "es2017",
-      "lib": [
-        "es2017",
-      ],
-      "module": "commonjs",
-      "allowJs": false,
-      "sourceMap": true,
-      "strict": false,
-      "declaration": true,
-      "importHelpers": true,
-      "typeRoots": ["./node_modules/@types", "./typings"],
+    "outDir": "./dist",
+    "pretty": true,
+    "target": "es2019",
+    "lib": ["es2019", "dom"],
+    "module": "commonjs",
+    "allowJs": false,
+    "sourceMap": true,
+    "strict": false,
+    "declaration": true,
+    "importHelpers": true,
+    "typeRoots": ["./node_modules/@types", "./typings"]
   },
-  "include": [
-      "./lib/**/*", "typings/tap/index.d.ts",
-  ]
+  "include": ["./lib/**/*", "typings/tap/index.d.ts"]
 }


### PR DESCRIPTION
The base path default to SNYK_API_REST_URL which is "https://api.snyk.io/rest".

We don't need "/rest" in the path given to snykHttpClient.