### PR TITLE
fix: return artifactId sha1 combination from package info as fallback

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -51,7 +51,10 @@ export async function getMavenPackageInfo(
     );
   }
 
-  return `${groupId || 'unknown'}:${artifactId || 'unknown'}@${
-    version || 'unknown'
-  }`;
+  const groupIdString = groupId || 'unknown';
+  const artifactIdString =
+    artifactId ||
+    `${depCoords.artifactId ? `${depCoords.artifactId}-` : ''}${sha1}`;
+  const versionString = version || 'unknown';
+  return `${groupIdString}:${artifactIdString}@${versionString}`;
 }

--- a/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
+++ b/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "gradle"
+  },
+  "pkgs": [
+    {
+      "id": ".@unspecified",
+      "info": {
+        "name": ".",
+        "version": "unspecified"
+      }
+    },
+    {
+      "id": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown",
+      "info": {
+        "name": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8",
+        "version": "unknown"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": ".@unspecified",
+        "deps": [
+          {
+            "nodeId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown"
+          }
+        ]
+      },
+      {
+        "nodeId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown",
+        "pkgId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/test/functional/search.spec.ts
+++ b/test/functional/search.spec.ts
@@ -3,48 +3,41 @@ import type { NeedleResponse } from 'needle';
 import { getMavenPackageInfo } from '../../lib/search';
 
 describe('should get Maven package info', () => {
+  const sha1 = 'ba55c13d7ac2fd44df9cc8074455719a33f375b9'; // log4j-core
   it('returns maven coordinate string when purl string returned', async () => {
-    const received = await getMavenPackageInfo(
-      'ba55c13d7ac2fd44df9cc8074455719a33f375b9', // log4j-core
-      {},
-      async () => ({
-        res: {} as NeedleResponse,
-        body: {
-          data: [
-            {
-              id: 'pkg:maven/org.apache.logging.log4j/log4j-core@2.15.0',
-              type: 'package',
-            },
-          ],
-        },
-      }),
-    );
+    const received = await getMavenPackageInfo(sha1, {}, async () => ({
+      res: {} as NeedleResponse,
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/org.apache.logging.log4j/log4j-core@2.15.0',
+            type: 'package',
+          },
+        ],
+      },
+    }));
     expect(received).toBe('org.apache.logging.log4j:log4j-core@2.15.0');
   });
 
   it("should return 'unknown' values when partial purl string returned", async () => {
-    const received = await getMavenPackageInfo(
-      'ba55c13d7ac2fd44df9cc8074455719a33f375b9', // log4j-core
-      {},
-      async () => ({
-        res: {} as NeedleResponse,
-        body: {
-          data: [
-            {
-              id: 'pkg:maven/log4j-core@2.15.0',
-              type: 'package',
-            },
-          ],
-        },
-      }),
-    );
+    const received = await getMavenPackageInfo(sha1, {}, async () => ({
+      res: {} as NeedleResponse,
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/log4j-core@2.15.0',
+            type: 'package',
+          },
+        ],
+      },
+    }));
     expect(received).toBe('unknown:log4j-core@2.15.0');
   });
 
-  it("should return all 'unknown' values when no/non purl string returned", async () => {
+  it("should return 'unknown' values with unique artifact id when no/non purl string returned", async () => {
     const noPurlStringReceived = await getMavenPackageInfo(
-      'ba55c13d7ac2fd44df9cc8074455719a33f375b9', // log4j-core
-      {},
+      sha1,
+      { artifactId: 'artifactId1' },
       async () => ({
         res: {} as NeedleResponse,
         body: {
@@ -52,10 +45,27 @@ describe('should get Maven package info', () => {
         },
       }),
     );
-    expect(noPurlStringReceived).toBe('unknown:unknown@unknown');
+    expect(noPurlStringReceived).toBe(`unknown:artifactId1-${sha1}@unknown`);
 
     const nonPurlStringReceived = await getMavenPackageInfo(
-      'ba55c13d7ac2fd44df9cc8074455719a33f375b9', // log4j-core
+      sha1,
+      { artifactId: 'artifactId1' },
+      async () => ({
+        res: {} as NeedleResponse,
+        body: {
+          data: [
+            {
+              id: 'corruptedId',
+              type: 'package',
+            },
+          ],
+        },
+      }),
+    );
+    expect(nonPurlStringReceived).toBe(`unknown:artifactId1-${sha1}@unknown`);
+
+    const nonPurlStringReceived2 = await getMavenPackageInfo(
+      sha1,
       {},
       async () => ({
         res: {} as NeedleResponse,
@@ -69,6 +79,50 @@ describe('should get Maven package info', () => {
         },
       }),
     );
-    expect(nonPurlStringReceived).toBe('unknown:unknown@unknown');
+    expect(nonPurlStringReceived2).toBe(`unknown:${sha1}@unknown`);
+  });
+
+  it("should return 'unknown' values with unique artifact id for separate packages when all have partial/no/non purl string returned", async () => {
+    const received1 = await getMavenPackageInfo(sha1, {}, async () => ({
+      res: {} as NeedleResponse,
+      body: {
+        data: [
+          {
+            id: 'corruptedId1',
+            type: 'package',
+          },
+        ],
+      },
+    }));
+
+    const secondSha1 = 'ca55c13d7ac2fd44df9cc8074455719a33f375b9';
+    const received2 = await getMavenPackageInfo(secondSha1, {}, async () => ({
+      res: {} as NeedleResponse,
+      body: {
+        data: [
+          {
+            id: 'corruptedId2',
+            type: 'package',
+          },
+        ],
+      },
+    }));
+
+    const thirdSha1 = 'da55c13d7ac2fd44df9cc8074455719a33f375b9';
+    const received3 = await getMavenPackageInfo(thirdSha1, {}, async () => ({
+      res: {} as NeedleResponse,
+      body: {
+        data: [
+          {
+            id: 'corruptedId3',
+            type: 'package',
+          },
+        ],
+      },
+    }));
+
+    const coordStringArr = [received1, received2, received3];
+    // check there are unique coord strings
+    expect(new Set(coordStringArr).size).toBe(coordStringArr.length);
   });
 });

--- a/test/system/fixtures-with-wrappers.test.ts
+++ b/test/system/fixtures-with-wrappers.test.ts
@@ -1,21 +1,12 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { createFromJSON } from '@snyk/dep-graph';
+import { NeedleResponse } from 'needle';
 
 import { getPathToFixture } from '../common';
 import { inspect } from '../../lib';
-import type { PomCoords } from '../../lib/types';
-
-jest.mock('../../lib/index.ts', () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual('../../lib/index.ts'),
-    getMavenPackageInfo: jest.fn(
-      (_, depCoords: PomCoords) =>
-        `${depCoords.groupId}:${depCoords.artifactId}@${depCoords.version}`,
-    ),
-  };
-});
+import * as search from '../../lib/search';
+import type { PomCoords, SnykHttpClient } from '../../lib/types';
 
 // specify fixtures to test, or leave empty to test all fixtures
 let fixtures: string[] = [];
@@ -24,7 +15,7 @@ if (!fixtures.length) fixtures = fs.readdirSync(getPathToFixture());
 
 describe('inspect() fixtures', () => {
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   fixtures.forEach((fixtureName) => {
@@ -47,14 +38,65 @@ describe('inspect() fixtures', () => {
     }, 100000);
   });
 
+  // gradleNormalizeDeps
   fixtures.forEach((fixtureName) => {
     const isKotlin = fixtureName.startsWith('kts');
     const dsl = isKotlin ? 'Kotlin' : 'Groovy';
     test(`${dsl} fixture: ${fixtureName} - gradleNormalizeDeps`, async () => {
+      jest.spyOn(search, 'getMavenPackageInfo').mockImplementation(
+        async (
+          _sha1: string,
+          depCoords: Partial<PomCoords>,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          _snykHttpClient: SnykHttpClient,
+        ) =>
+          `${depCoords.groupId}:${depCoords.artifactId}@${depCoords.version}`,
+      );
       const fixturePath = getPathToFixture(fixtureName);
       const buildFileName = isKotlin ? 'build.gradle.kts' : 'build.gradle';
       const pathToBuildConfig = path.join(fixturePath, buildFileName);
       const expectedDepGraphJson = require(`${fixturePath}/dep-graph.json`);
+      const expectedDepGraph = createFromJSON(expectedDepGraphJson);
+
+      const result = await inspect('.', pathToBuildConfig, {
+        gradleNormalizeDeps: true,
+      });
+
+      const resultMatchesExpected =
+        result.dependencyGraph &&
+        expectedDepGraph.equals(result.dependencyGraph);
+
+      expect(resultMatchesExpected).toBeTruthy();
+    }, 100000);
+  });
+
+  // gradleNormalizeDeps - failed /packages search
+  ['basic-with-deps'].forEach((fixtureName) => {
+    const isKotlin = fixtureName.startsWith('kts');
+    const dsl = isKotlin ? 'Kotlin' : 'Groovy';
+    test(`${dsl} fixture: ${fixtureName} - gradleNormalizeDeps (failed /packages search)`, async () => {
+      const mockNeedleResponse = {
+        statusCode: 500,
+      } as unknown as NeedleResponse;
+      const snykHttpClientMock = async () => ({
+        res: mockNeedleResponse,
+        body: null,
+      });
+      const original = search.getMavenPackageInfo;
+      jest.spyOn(search, 'getMavenPackageInfo').mockImplementation(
+        async (
+          sha1: string,
+          depCoords: Partial<PomCoords>,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          _snykHttpClient: SnykHttpClient,
+        ) => {
+          return original(sha1, depCoords, snykHttpClientMock);
+        },
+      );
+      const fixturePath = getPathToFixture(fixtureName);
+      const buildFileName = isKotlin ? 'build.gradle.kts' : 'build.gradle';
+      const pathToBuildConfig = path.join(fixturePath, buildFileName);
+      const expectedDepGraphJson = require(`${fixturePath}/dep-graph-gradleNormalizeDeps-failed-search.json`);
       const expectedDepGraph = createFromJSON(expectedDepGraphJson);
 
       const result = await inspect('.', pathToBuildConfig, {


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy

### What this does

In the situation there are multiple failed /packages searches, we put all deps into one direct 'unknown' dep. This work adds a fallback to use a combination of the artifactId and sha1 instead as unique identifier.

