### PR TITLE
chore: improve jest tests speed by limiting number of workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ defaults: &defaults
 windows_defaults: &windows_defaults
   environment:
     npm_config_loglevel: silent
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072 -XX:+HeapDumpOnOutOfMemoryError"'
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072 -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
   executor:
     name: win/default
     size: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ defaults: &defaults
 windows_defaults: &windows_defaults
   environment:
     npm_config_loglevel: silent
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072 -XX:+HeapDumpOnOutOfMemoryError"'
   executor:
     name: win/default
     size: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,41 +166,6 @@ jobs:
           name: Run tests
           command: npm test
 
-  test-fixtures-with-wrappers-unix:
-    <<: *defaults
-    docker:
-      - image: circleci/node:16
-    environment:
-      JDK: 17.0.3.6.1-amzn
-    steps:
-      - checkout
-      - install_sdkman
-      - install_jdk_unix:
-          jdk_version: 17.0.3.6.1-amzn
-      - install_deps
-      - show_node_version
-      - run:
-          name: Run tests
-          command: npm run test-fixtures
-
-  test-fixtures-with-wrappers-windows:
-    <<: *defaults
-    <<: *windows_defaults
-    environment:
-      JDK: '17'
-    steps:
-      - run: git config --global core.autocrlf false
-      - checkout
-      - install_node_npm:
-          node_version: '16'
-      - install_jdk_windows:
-          jdk_version: '17'
-      - install_deps
-      - show_node_version
-      - run:
-          name: Run tests
-          command: npm run test-fixtures
-
   release:
     <<: *defaults
     docker:
@@ -229,12 +194,6 @@ workflows:
           name: Test OS=Windows Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_win
-      - test-fixtures-with-wrappers-unix:
-          name: Test Fixtures OS=Unix Node=16 JDK=17.0.3.6.1-amzn Gradle=7.4.2
-          context: nodejs-install
-      - test-fixtures-with-wrappers-windows:
-          name: Test Fixtures OS=Windows Node=16 JDK=17 Gradle=7.4.2
-          context: nodejs-install
 
       - release:
           name: Release

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
     "test": "tsc -p tsconfig-test.json && npm run test-manual && npm run test-functional && npm run test-system",
-    "test-functional": "jest test/functional -b",
-    "test-system": "jest test/system -b  --testTimeout=150000",
-    "test-fixtures": "tsc -p tsconfig-test.json && jest test/system/fixtures-with-wrappers.test.ts -b  --testTimeout=150000",
-    "test-manual": "jest test/manual -b"
+    "test-functional": "jest test/functional -b  --maxWorkers=2",
+    "test-system": "jest test/system -b  --testTimeout=150000  --maxWorkers=2",
+    "test-fixtures": "tsc -p tsconfig-test.json && jest test/system/fixtures-with-wrappers.test.ts -b  --testTimeout=150000 --maxWorkers=2",
+    "test-manual": "jest test/manual -b  --maxWorkers=2"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,7 @@
     "lint": "eslint --color --cache '{lib,test}/**/*.{js,ts}' && prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "tsc -p tsconfig-test.json && npm run test-manual && npm run test-functional && npm run test-system",
-    "test-functional": "jest test/functional -b  --maxWorkers=2",
-    "test-system": "jest test/system -b  --testTimeout=150000  --maxWorkers=2",
-    "test-fixtures": "tsc -p tsconfig-test.json && jest test/system/fixtures-with-wrappers.test.ts -b  --testTimeout=150000 --maxWorkers=2",
-    "test-manual": "jest test/manual -b  --maxWorkers=2"
+    "test": "tsc -p tsconfig-test.json && jest -b --maxWorkers=2 --testTimeout=150000"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
From[ this blog post](https://support.circleci.com/hc/en-us/articles/360005442714-Your-test-tools-are-smart-and-that-s-a-problem-Learn-about-when-optimization-goes-wrong-):
using the docker executor will often have your job running in a VM with thirty-two CPU cores available. This causes problems with testing tools like `jest` which by default will spawn workers based on the number of available CPU cores. It will think it has access to thirty-two cores, but in reality, while using a medium resource class, it only has access to two. 

To prevent jest tests timing out, limit the number of workers to 2.

Clean up the list of npm scripts. We can now run them all together (change in package.json and circle ci config)

Following advice [here](https://discuss.circleci.com/t/why-does-gradle-time-out/16913) the heap size should not grow larger than 3GB available to Gradle. 

As it is the Gradle daemon that usually times out, disable it. From [this CircleCI blog post](https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues): The [daemon runs by default ](https://docs.gradle.org/current/userguide/command_line_interface.html#gradle_daemon_options)and is helpful when running locally as it speeds up recompilation.
This is not needed in continuous integration since every compilation is fresh. It takes up more memory for no benefit.