### PR TITLE
add gradle.properties for all fixtures, disable daemon

### DIFF
--- a/test/fixtures-with-wrappers/basic-with-deps/gradle.properties
+++ b/test/fixtures-with-wrappers/basic-with-deps/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/basic-with-failed-dep/gradle.properties
+++ b/test/fixtures-with-wrappers/basic-with-failed-dep/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/configuration-consistency/gradle.properties
+++ b/test/fixtures-with-wrappers/configuration-consistency/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/custom-configuration/gradle.properties
+++ b/test/fixtures-with-wrappers/custom-configuration/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/empty-build-gradle-in-root/gradle.properties
+++ b/test/fixtures-with-wrappers/empty-build-gradle-in-root/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/empty-project/gradle.properties
+++ b/test/fixtures-with-wrappers/empty-project/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/kts-basic-with-deps/gradle.properties
+++ b/test/fixtures-with-wrappers/kts-basic-with-deps/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/kts-configuration-consistency/gradle.properties
+++ b/test/fixtures-with-wrappers/kts-configuration-consistency/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/kts-strict-lock-mode/gradle.properties
+++ b/test/fixtures-with-wrappers/kts-strict-lock-mode/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/kts-version-catalog-module/gradle.properties
+++ b/test/fixtures-with-wrappers/kts-version-catalog-module/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/platform-project-mvn-bom/gradle.properties
+++ b/test/fixtures-with-wrappers/platform-project-mvn-bom/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/repo-content-filtering/gradle.properties
+++ b/test/fixtures-with-wrappers/repo-content-filtering/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/version-catalog-settings/gradle.properties
+++ b/test/fixtures-with-wrappers/version-catalog-settings/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/version-catalog-toml/gradle.properties
+++ b/test/fixtures-with-wrappers/version-catalog-toml/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures-with-wrappers/with-lock-file/gradle.properties
+++ b/test/fixtures-with-wrappers/with-lock-file/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/android-cannot-auto-resolve/gradle.properties
+++ b/test/fixtures/android-cannot-auto-resolve/gradle.properties
@@ -10,6 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
+org.gradle.daemon=false
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/test/fixtures/api-configuration/gradle.properties
+++ b/test/fixtures/api-configuration/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/gradle-kts/gradle.properties
+++ b/test/fixtures/gradle-kts/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/java-reachability-playground/gradle.properties
+++ b/test/fixtures/java-reachability-playground/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/malformed-build-gradle/gradle.properties
+++ b/test/fixtures/malformed-build-gradle/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-config-attributes-subproject/gradle.properties
+++ b/test/fixtures/multi-config-attributes-subproject/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-config-attributes/gradle.properties
+++ b/test/fixtures/multi-config-attributes/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-config/gradle.properties
+++ b/test/fixtures/multi-config/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project gradle wrapper/gradle.properties
+++ b/test/fixtures/multi-project gradle wrapper/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project-dependency-cycle/gradle.properties
+++ b/test/fixtures/multi-project-dependency-cycle/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project-different-names/gradle.properties
+++ b/test/fixtures/multi-project-different-names/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project-parallel/gradle.properties
+++ b/test/fixtures/multi-project-parallel/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 
+org.gradle.daemon=false

--- a/test/fixtures/multi-project-same-name/gradle.properties
+++ b/test/fixtures/multi-project-same-name/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project-some-unscannable/gradle.properties
+++ b/test/fixtures/multi-project-some-unscannable/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/multi-project/gradle.properties
+++ b/test/fixtures/multi-project/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/no wrapper/gradle.properties
+++ b/test/fixtures/no wrapper/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/shared-config/gradle.properties
+++ b/test/fixtures/shared-config/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/subproject-with-same-name-as-root/gradle.properties
+++ b/test/fixtures/subproject-with-same-name-as-root/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/subprojects-same-name/gradle.properties
+++ b/test/fixtures/subprojects-same-name/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/subprojects-with-same-name-dependent/gradle.properties
+++ b/test/fixtures/subprojects-with-same-name-dependent/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/successful-scan-with-unresolved-custom-configs/gradle.properties
+++ b/test/fixtures/successful-scan-with-unresolved-custom-configs/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/variant-conflicts/gradle.properties
+++ b/test/fixtures/variant-conflicts/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/version-conflict-resolution/gradle.properties
+++ b/test/fixtures/version-conflict-resolution/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/with-init-script/gradle.properties
+++ b/test/fixtures/with-init-script/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/with-wrapper-in-root/gradle.properties
+++ b/test/fixtures/with-wrapper-in-root/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/test/fixtures/with-wrapper/gradle.properties
+++ b/test/fixtures/with-wrapper/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
Jest tests still fail with `Timeout waiting to connect to the Gradle daemon.` - looks like including the flag in `GRADLE_OPTS` env variable didn't disable the daemon but adding the setting `org.gradle.daemon=false` to gradle.properties is supposed to do the magic. Using Gradle daemon doesn't have any benefits in CircleCI.