### PR TITLE
feat: for Gradle 7 disable configuration cache by default

### DIFF
--- a/test/functional/gradle-plugin.spec.ts
+++ b/test/functional/gradle-plugin.spec.ts
@@ -1,10 +1,17 @@
 import { exportsForTests as testableMethods } from '../../lib';
 
 const JEST_TIMEOUT = 15000;
+const gradleVersion = 'Gradle 6';
 
 describe('Gradle Plugin', () => {
   it('check build args (plain console output)', () => {
-    const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {});
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {},
+      gradleVersion,
+    );
     expect(result).toEqual([
       'snykResolvedDepsJson',
       '-q',
@@ -18,10 +25,16 @@ describe('Gradle Plugin', () => {
   });
 
   it('check build args with array (new configuration arg)', async () => {
-    const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {
-      'configuration-matching': 'confRegex',
-      args: ['--build-file', 'build.gradle'],
-    });
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {
+        'configuration-matching': 'confRegex',
+        args: ['--build-file', 'build.gradle'],
+      },
+      gradleVersion,
+    );
     expect(result).toEqual([
       'snykResolvedDepsJson',
       '-q',
@@ -38,11 +51,17 @@ describe('Gradle Plugin', () => {
   });
 
   it('check build args with array (new configuration arg) with --deamon', async () => {
-    const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {
-      daemon: true,
-      'configuration-matching': 'confRegex',
-      args: ['--build-file', 'build.gradle'],
-    });
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {
+        daemon: true,
+        'configuration-matching': 'confRegex',
+        args: ['--build-file', 'build.gradle'],
+      },
+      gradleVersion,
+    );
     expect(result).toEqual([
       'snykResolvedDepsJson',
       '-q',
@@ -58,9 +77,15 @@ describe('Gradle Plugin', () => {
   });
 
   it('check build args with array (legacy configuration arg)', async () => {
-    const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {
-      args: ['--build-file', 'build.gradle', '--configuration=compile'],
-    });
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {
+        args: ['--build-file', 'build.gradle', '--configuration=compile'],
+      },
+      gradleVersion,
+    );
     expect(result).toEqual([
       'snykResolvedDepsJson',
       '-q',
@@ -79,14 +104,21 @@ describe('Gradle Plugin', () => {
   it(
     'check build args with scan all subprojects',
     async () => {
-      const result = testableMethods.buildArgs('.', null, '/tmp/init.gradle', {
-        allSubProjects: true,
-        args: ['--build-file', 'build.gradle', '--configuration', 'compile'],
-      });
+      const result = testableMethods.buildArgs(
+        '.',
+        null,
+        '/tmp/init.gradle',
+        {
+          allSubProjects: true,
+          args: ['--build-file', 'build.gradle', '--configuration', 'compile'],
+        },
+        gradleVersion,
+      );
       expect(result).toEqual([
         'snykResolvedDepsJson',
         '-q',
         '--no-daemon',
+
         '-Dorg.gradle.parallel=',
         '-Dorg.gradle.console=plain',
         '-I',
@@ -98,4 +130,47 @@ describe('Gradle Plugin', () => {
     },
     JEST_TIMEOUT,
   );
+
+  it('make sure configuration cache is switched off even if requested', () => {
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {
+        args: ['--configuration-cache'],
+      },
+      gradleVersion,
+    );
+    expect(result).toEqual([
+      'snykResolvedDepsJson',
+      '-q',
+      '--no-daemon',
+      '-Dorg.gradle.parallel=',
+      '-Dorg.gradle.console=plain',
+      '-PonlySubProject=.',
+      '-I',
+      '/tmp/init.gradle',
+    ]);
+  });
+
+  it('make sure configuration cache is switched off for Gradle 7', () => {
+    const result = testableMethods.buildArgs(
+      '.',
+      null,
+      '/tmp/init.gradle',
+      {},
+      'Gradle 7',
+    );
+    expect(result).toEqual([
+      'snykResolvedDepsJson',
+      '-q',
+      '--no-daemon',
+      '-Dorg.gradle.parallel=',
+      '-Dorg.gradle.console=plain',
+      '-PonlySubProject=.',
+      '-I',
+      '/tmp/init.gradle',
+      '--no-configuration-cache',
+    ]);
+  });
 });


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
New feature for Gradle 7, [configuration caching](https://docs.gradle.org/7.4.2/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
), breaks snyk. 
If a user passes `--configuration-cache` we will remove it, if it's set in `gradle.properties` we have to force switching it off by using `--no-configuration-cache`. This flag didn't exist before Gradle 7 so we need to check the version before adding it. 