### PR TITLE
test: clean up fixtures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ defaults: &defaults
   working_directory: ~/snyk-gradle-plugin
 
 windows_defaults: &windows_defaults
-  environment:
-    npm_config_loglevel: silent
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072 -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
   executor:
     name: win/default
     size: large
@@ -132,6 +129,9 @@ jobs:
     <<: *windows_defaults
     environment:
       JDK: << parameters.jdk_version >>
+      npm_config_loglevel: silent
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.daemon.idletimeout=180000 -Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process'
+      JAVA_OPTS: ' -Xmx512M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
     steps:
       - run: git config --global core.autocrlf false
       - checkout
@@ -153,7 +153,6 @@ jobs:
       - image: circleci/node:<< parameters.node_version >>
     environment:
       GRADLE_VERSION: << parameters.gradle_version >>
-      JDK: << parameters.jdk_version >>
     steps:
       - checkout
       - install_sdkman

--- a/test/fixtures/custom-resolution-strategy-via-all/build.gradle
+++ b/test/fixtures/custom-resolution-strategy-via-all/build.gradle
@@ -11,11 +11,8 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.guava:guava:18.0'
-  compile 'batik:batik-dom:1.6'
   compile 'commons-discovery:commons-discovery:0.2'
   compile 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -51,8 +48,8 @@ install {
 // See https://docs.gradle.org/current/userguide/customizing_dependency_resolution_behavior.html#sec:dependency_resolve_rules
 configurations.all {
   resolutionStrategy.eachDependency { details ->
-    if (details.requested.group == 'com.android.tools' && details.requested.name == 'annotations') {
-      details.useVersion '25.2.0'
+    if (details.requested.group == 'commons-logging' && details.requested.name == 'commons-logging') {
+      details.useVersion '1.0.3'
     }
   }
 }

--- a/test/fixtures/custom-resolution-strategy-via-asterisk/build.gradle
+++ b/test/fixtures/custom-resolution-strategy-via-asterisk/build.gradle
@@ -11,11 +11,8 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.guava:guava:18.0'
-  compile 'batik:batik-dom:1.6'
   compile 'commons-discovery:commons-discovery:0.2'
   compile 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -50,8 +47,8 @@ install {
 
 Closure versionStrategy = {
   eachDependency { details ->
-    if (details.requested.group == 'com.android.tools' && details.requested.name == 'annotations') {
-      details.useVersion '25.2.0'
+    if (details.requested.group == 'commons-logging' && details.requested.name == 'commons-logging') {
+      details.useVersion '1.0.3'
     }
   }
 }

--- a/test/fixtures/multi-project gradle wrapper/subproj/build.gradle
+++ b/test/fixtures/multi-project gradle wrapper/subproj/build.gradle
@@ -11,11 +11,8 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.guava:guava:18.0'
-  compile 'batik:batik-dom:1.6'
   compile 'commons-discovery:commons-discovery:0.2'
   compile 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
@@ -13,9 +13,6 @@ repositories {
 dependencies {
   compile 'com.google.guava:guava:18.0'
   compile 'batik:batik-dom:1.6'
-  compile 'commons-discovery:commons-discovery:0.2'
-  compileOnly 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
   compile project(':')
 }
 

--- a/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
+++ b/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
@@ -13,9 +13,6 @@ repositories {
 dependencies {
   compile 'com.google.guava:guava:18.0'
   compile 'batik:batik-dom:1.6'
-  compile 'commons-discovery:commons-discovery:0.2'
-  compileOnly 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/test/fixtures/no wrapper/build.gradle
+++ b/test/fixtures/no wrapper/build.gradle
@@ -11,11 +11,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.guava:guava:18.0'
   compile 'batik:batik-dom:1.6'
-  compile 'commons-discovery:commons-discovery:0.2'
-  compile 'axis:axis:1.3'
-  compile 'com.android.tools.build:builder:2.3.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -251,9 +251,9 @@ test('multi-project-some-unscannable: gradle-sub-project for a good subproject w
     nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
   });
 
-  expect(
-    nodeIds.indexOf('com.android.tools:annotations@25.3.0'),
-  ).toBeGreaterThanOrEqual(-1);
+  expect(nodeIds.indexOf('com.google.guava:guava@18.0')).toBeGreaterThanOrEqual(
+    0,
+  );
 });
 
 test('allSubProjects incompatible with gradle-sub-project', async () => {

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -15,9 +15,7 @@ test('run inspect()', async () => {
     nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
   });
 
-  expect(
-    nodeIds.indexOf('com.android.tools:annotations@25.3.0'),
-  ).toBeGreaterThanOrEqual(0);
+  expect(nodeIds.indexOf('batik:batik-dom@1.6')).toBeGreaterThanOrEqual(0);
 });
 
 test('run inspect() with gradle init script', async () => {
@@ -30,12 +28,10 @@ test('run inspect() with gradle init script', async () => {
     nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
   });
 
-  expect(
-    nodeIds.indexOf('com.android.tools:annotations@25.3.0'),
-  ).toBeGreaterThanOrEqual(0);
+  expect(nodeIds.indexOf('batik:batik-dom@1.6')).toBeGreaterThanOrEqual(0);
 });
 
-test('run inspect() with on project that depends on gradle init script', async () => {
+test('run inspect() on project that depends on gradle init script', async () => {
   const result = await inspect('.', path.join(withInitScript, 'build.gradle'), {
     initScript: path.join(withInitScript, 'init.gradle'),
   });
@@ -122,9 +118,7 @@ test('multi-config: only deps for specified conf are picked up (fuzzy match)', a
     nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
   });
 
-  expect(
-    nodeIds.indexOf('com.android.tools.build:builder@2.3.0'),
-  ).toBeGreaterThanOrEqual(-1);
+  expect(nodeIds.indexOf('com.android.tools.build:builder@2.3.0')).toBe(-1);
   expect(
     nodeIds.indexOf('javax.servlet:servlet-api@2.5'),
   ).toBeGreaterThanOrEqual(0);
@@ -149,12 +143,10 @@ test('multi-config: only deps for specified conf are picked up (using legacy CLI
     nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
   });
 
-  expect(
-    nodeIds.indexOf('com.android.tools.build:builder@2.3.0'),
-  ).toBeGreaterThanOrEqual(-1);
+  expect(nodeIds.indexOf('com.android.tools.build:builder@2.3.0')).toBe(-1);
   expect(
     nodeIds.indexOf('javax.servlet:servlet-api@2.5'),
-  ).toBeGreaterThanOrEqual(-1);
+  ).toBeGreaterThanOrEqual(0);
 
   // double parsing to have access to internal depGraph data, no methods available to properly
   // return the deps nodeIds list that belongs to a node
@@ -174,11 +166,11 @@ test('custom dependency resolution via configurations.all is supported', async (
   });
 
   expect(
-    nodeIds.indexOf('com.android.tools:annotations@25.2.0'),
-  ).toBeGreaterThanOrEqual(-1); //forced, normally 25.3.0
+    nodeIds.indexOf('commons-logging:commons-logging@1.0.3'),
+  ).toBeGreaterThanOrEqual(0); //forced, normally 1.0.4
 });
 
-test('custom dependency resolution via configurations* is NOT supported (known problem)', async () => {
+test('custom dependency resolution via configurations* is supported', async () => {
   // See the test case for more details
   const result = await inspect(
     '.',
@@ -195,8 +187,8 @@ test('custom dependency resolution via configurations* is NOT supported (known p
   });
 
   expect(
-    nodeIds.indexOf('com.android.tools:annotations@25.2.0'),
-  ).toBeGreaterThanOrEqual(-1); // 25.2.0 instead of 25.3.0 due of dependency conflict resolution
+    nodeIds.indexOf('commons-logging:commons-logging@1.0.3'),
+  ).toBeGreaterThanOrEqual(0); //forced, normally 1.0.4
 });
 
 test('repeated transitive lines terminated at duplicate node and labeled pruned', async () => {


### PR DESCRIPTION
- [X] Commit history is tidy

### What this does
Removes some of the bigger dependencies in fixtures in favour of smaller to speed up tests

GRADLE_OPTS environment variable controls the command line client, which is used to display console output. Increase memory available to this process. Make sure there are no idle daemons hanging around (their default timeout is 3 hrs).

The -XX:+HeapDumpOnOutOfMemoryError command-line option tells the HotSpot VM to generate a heap dump when an allocation from the Java heap or the permanent generation cannot be satisfied. There is no overhead in running with this option, and so it can be useful for production systems where OutOfMemoryError takes a long time to surface.