### PR TITLE
chore: pin semantic-release to pre-20 (node 18+)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     steps:
       - checkout
       - install_deps
-      - run: sudo npm i -g semantic-release @semantic-release/exec pkg
+      - run: sudo npm i -g semantic-release@19 @semantic-release/exec pkg
       - run:
           name: Publish to GitHub
           command: semantic-release


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written
- [x] Commit history is tidy

### What this does

[_Explain why this PR exists_](https://github.com/snyk/registry/pull/30234)

- pin `semantic-release` to pre-20 (which requires node 18+) to unblock the release step
