### PR TITLE
feat: allow gradle daemon on unix

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -718,7 +718,8 @@ function buildArgs(
     args.push('--init-script', formattedInitScript);
   }
 
-  if (!options.daemon) {
+  const isWin = /^win/.test(os.platform());
+  if (isWin && !options.daemon) {
     args.push('--no-daemon');
   }
 

--- a/test/functional/gradle-plugin.spec.ts
+++ b/test/functional/gradle-plugin.spec.ts
@@ -12,16 +12,17 @@ describe('Gradle Plugin', () => {
       {},
       gradleVersion,
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      '--no-daemon',
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+      ]),
+    );
   });
 
   it('check build args with array (new configuration arg)', async () => {
@@ -35,19 +36,20 @@ describe('Gradle Plugin', () => {
       },
       gradleVersion,
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      `-Pconfiguration=confRegex`,
-      '--no-daemon',
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-      '--build-file',
-      'build.gradle',
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        `-Pconfiguration=confRegex`,
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+        '--build-file',
+        'build.gradle',
+      ]),
+    );
   });
 
   it('check build args with array (new configuration arg) with --deamon', async () => {
@@ -62,18 +64,20 @@ describe('Gradle Plugin', () => {
       },
       gradleVersion,
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      `-Pconfiguration=confRegex`,
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-      '--build-file',
-      'build.gradle',
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        `-Pconfiguration=confRegex`,
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+        '--build-file',
+        'build.gradle',
+      ]),
+    );
   });
 
   it('check build args with array (legacy configuration arg)', async () => {
@@ -86,19 +90,20 @@ describe('Gradle Plugin', () => {
       },
       gradleVersion,
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      '--no-daemon',
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-      '--build-file',
-      'build.gradle',
-      `-Pconfiguration=^compile$`,
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+        '--build-file',
+        'build.gradle',
+        `-Pconfiguration=^compile$`,
+      ]),
+    );
   });
 
   it(
@@ -114,19 +119,19 @@ describe('Gradle Plugin', () => {
         },
         gradleVersion,
       );
-      expect(result).toEqual([
-        'snykResolvedDepsJson',
-        '-q',
-        '--no-daemon',
-
-        '-Dorg.gradle.parallel=',
-        '-Dorg.gradle.console=plain',
-        '-I',
-        '/tmp/init.gradle',
-        '--build-file',
-        'build.gradle',
-        `-Pconfiguration=^compile$`,
-      ]);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          'snykResolvedDepsJson',
+          '-q',
+          '-Dorg.gradle.parallel=',
+          '-Dorg.gradle.console=plain',
+          '-I',
+          '/tmp/init.gradle',
+          '--build-file',
+          'build.gradle',
+          `-Pconfiguration=^compile$`,
+        ]),
+      );
     },
     JEST_TIMEOUT,
   );
@@ -141,16 +146,17 @@ describe('Gradle Plugin', () => {
       },
       gradleVersion,
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      '--no-daemon',
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+      ]),
+    );
   });
 
   it('make sure configuration cache is switched off for Gradle 7', () => {
@@ -161,16 +167,17 @@ describe('Gradle Plugin', () => {
       {},
       'Gradle 7',
     );
-    expect(result).toEqual([
-      'snykResolvedDepsJson',
-      '-q',
-      '--no-daemon',
-      '-Dorg.gradle.parallel=',
-      '-Dorg.gradle.console=plain',
-      '-PonlySubProject=.',
-      '-I',
-      '/tmp/init.gradle',
-      '--no-configuration-cache',
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        'snykResolvedDepsJson',
+        '-q',
+        '-Dorg.gradle.parallel=',
+        '-Dorg.gradle.console=plain',
+        '-PonlySubProject=.',
+        '-I',
+        '/tmp/init.gradle',
+        '--no-configuration-cache',
+      ]),
+    );
   });
 });


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does
We hit performance issues when scanning large monorepos. Using Gradle daemon can improve performance by 15-75%, as per documentation: https://docs.gradle.org/current/userguide/gradle_daemon.html. 
We blocked using it by forcing the `--no-daemon` flag because it fails on Windows, as per [this comment  ](https://github.com/snyk/snyk-gradle-plugin/blob/6758a558fb0acd4c9f8b811f00f9c58df239d2ce/lib/index.ts#L66) but it seems to work and improve performance on Unix based systems.

