### PR TITLE
fix: bug in the CLI where envVars were not being restored correctly [HEAD-218]

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -8,14 +8,30 @@ const debugLogging = debugModule('snyk-gradle-plugin');
 export function execute(
   command: string,
   args: string[],
-  options: { cwd?: string },
+  options: { cwd?: string, env?: NodeJS.ProcessEnv },
   perLineCallback?: (s: string) => Promise<void>,
 ): Promise<string> {
-  const spawnOptions: childProcess.SpawnOptions = { shell: true };
-  if (options && options.cwd) {
+  const spawnOptions: childProcess.SpawnOptions = { shell: true, env: { ...process.env } };
+  if (options?.cwd) {
     spawnOptions.cwd = options.cwd;
   }
+  if (options?.env) {
+    spawnOptions.env = { ...process.env, ...options.env };
+  }
+
   args = quoteAll(args, spawnOptions);
+
+  // Before spawning an external process, we look if we need to restore the system proxy configuration,
+  // which overides the cli internal proxy configuration.
+  if (process.env.SNYK_SYSTEM_HTTP_PROXY !== undefined) {
+    spawnOptions.env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_HTTPS_PROXY !== undefined) {
+    spawnOptions.env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_NO_PROXY !== undefined) {
+    spawnOptions.env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
+  }
 
   return new Promise((resolve, reject) => {
     let stdout = '';

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -8,10 +8,13 @@ const debugLogging = debugModule('snyk-gradle-plugin');
 export function execute(
   command: string,
   args: string[],
-  options: { cwd?: string, env?: NodeJS.ProcessEnv },
+  options: { cwd?: string; env?: NodeJS.ProcessEnv },
   perLineCallback?: (s: string) => Promise<void>,
 ): Promise<string> {
-  const spawnOptions: childProcess.SpawnOptions = { shell: true, env: { ...process.env } };
+  const spawnOptions: childProcess.SpawnOptions = {
+    shell: true,
+    env: { ...process.env },
+  };
   if (options?.cwd) {
     spawnOptions.cwd = options.cwd;
   }

--- a/test/functional/sub-process.spec.ts
+++ b/test/functional/sub-process.spec.ts
@@ -12,17 +12,16 @@ describe('sub-process', () => {
   });
 
   it('restores proxy environment', async () => {
-    
-    process.env.SNYK_SYSTEM_HTTPS_PROXY = "http://1.1.1.1";
-    process.env.SNYK_SYSTEM_HTTP_PROXY = "http://2.2.2.2";
-    process.env.SNYK_SYSTEM_NO_PROXY = "snyk.com";
-    
-    process.env.HTTPS_PROXY = "http://127.0.0.1";
-    process.env.HTTP_PROXY = "http://127.0.0.1";
-    process.env.NO_PROXY = "example.com";
-    
+    process.env.SNYK_SYSTEM_HTTPS_PROXY = 'http://1.1.1.1';
+    process.env.SNYK_SYSTEM_HTTP_PROXY = 'http://2.2.2.2';
+    process.env.SNYK_SYSTEM_NO_PROXY = 'snyk.com';
+
+    process.env.HTTPS_PROXY = 'http://127.0.0.1';
+    process.env.HTTP_PROXY = 'http://127.0.0.1';
+    process.env.NO_PROXY = 'example.com';
+
     const result = await execute('env', [], {});
-    
+
     expect(result).toContain('HTTPS_PROXY=http://1.1.1.1');
     expect(process.env.HTTPS_PROXY).toStrictEqual('http://127.0.0.1');
 

--- a/test/functional/sub-process.spec.ts
+++ b/test/functional/sub-process.spec.ts
@@ -1,0 +1,35 @@
+import { execute } from '../../lib/sub-process';
+
+describe('sub-process', () => {
+  let preTestEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    preTestEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = { ...preTestEnv };
+  });
+
+  it('restores proxy environment', async () => {
+    
+    process.env.SNYK_SYSTEM_HTTPS_PROXY = "http://1.1.1.1";
+    process.env.SNYK_SYSTEM_HTTP_PROXY = "http://2.2.2.2";
+    process.env.SNYK_SYSTEM_NO_PROXY = "snyk.com";
+    
+    process.env.HTTPS_PROXY = "http://127.0.0.1";
+    process.env.HTTP_PROXY = "http://127.0.0.1";
+    process.env.NO_PROXY = "example.com";
+    
+    const result = await execute('env', [], {});
+    
+    expect(result).toContain('HTTPS_PROXY=http://1.1.1.1');
+    expect(process.env.HTTPS_PROXY).toStrictEqual('http://127.0.0.1');
+
+    expect(result).toContain('HTTP_PROXY=http://2.2.2.2');
+    expect(process.env.HTTP_PROXY).toStrictEqual('http://127.0.0.1');
+
+    expect(result).toContain('NO_PROXY=snyk.com');
+    expect(process.env.NO_PROXY).toStrictEqual('example.com');
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Commit history is tidy

### What this does
Fix a bug in the CLI where environment variables were not being restored correctly, due to an side effect when accessing shared memory.