### PR TITLE
fix: transitives when using gradle-normalize-deps

### DIFF
--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -42,6 +42,8 @@ export async function buildGraph(
     const item = queue.shift();
     if (!item) continue;
     let { id, parentId } = item;
+    // take a copy as id maybe mutated below and we need this id when finding childing in snykGraph
+    const snykGraphId = `${id}`;
     const node = snykGraph[id];
     if (!node) continue;
     let { name = 'unknown', version = 'unknown' } = node;
@@ -67,7 +69,7 @@ export async function buildGraph(
     }
     depGraphBuilder.addPkgNode({ name, version }, id);
     depGraphBuilder.connectDep(parentId, id);
-    queue.push(...findChildren(id, snykGraph)); // queue children
+    queue.push(...findChildren(snykGraphId, snykGraph)); // queue children
     visited.push(id);
   }
 

--- a/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
+++ b/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
@@ -17,6 +17,48 @@
         "name": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8",
         "version": "unknown"
       }
+    },
+    {
+      "id": "unknown:failureaccess-1dcf1de382a0bf95a3d8b0849546c88bac1292c9@unknown",
+      "info": {
+        "name": "unknown:failureaccess-1dcf1de382a0bf95a3d8b0849546c88bac1292c9",
+        "version": "unknown"
+      }
+    },
+    {
+      "id": "unknown:listenablefuture-b421526c5f297295adef1c886e5246c39d4ac629@unknown",
+      "info": {
+        "name": "unknown:listenablefuture-b421526c5f297295adef1c886e5246c39d4ac629",
+        "version": "unknown"
+      }
+    },
+    {
+      "id": "unknown:jsr305-25ea2e8b0c338a877313bd4672d3fe056ea78f0d@unknown",
+      "info": {
+        "name": "unknown:jsr305-25ea2e8b0c338a877313bd4672d3fe056ea78f0d",
+        "version": "unknown"
+      }
+    },
+    {
+      "id": "unknown:checker-qual-6b83e4a33220272c3a08991498ba9dc09519f190@unknown",
+      "info": {
+        "name": "unknown:checker-qual-6b83e4a33220272c3a08991498ba9dc09519f190",
+        "version": "unknown"
+      }
+    },
+    {
+      "id": "unknown:error_prone_annotations-562d366678b89ce5d6b6b82c1a073880341e3fba@unknown",
+      "info": {
+        "name": "unknown:error_prone_annotations-562d366678b89ce5d6b6b82c1a073880341e3fba",
+        "version": "unknown"
+      }
+    },
+    {
+      "id": "unknown:j2objc-annotations-ba035118bc8bac37d7eff77700720999acd9986d@unknown",
+      "info": {
+        "name": "unknown:j2objc-annotations-ba035118bc8bac37d7eff77700720999acd9986d",
+        "version": "unknown"
+      }
     }
   ],
   "graph": {
@@ -34,6 +76,55 @@
       {
         "nodeId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown",
         "pkgId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown",
+        "deps": [
+          {
+            "nodeId": "unknown:failureaccess-1dcf1de382a0bf95a3d8b0849546c88bac1292c9@unknown"
+          },
+          {
+            "nodeId": "unknown:listenablefuture-b421526c5f297295adef1c886e5246c39d4ac629@unknown"
+          },
+          {
+            "nodeId": "unknown:jsr305-25ea2e8b0c338a877313bd4672d3fe056ea78f0d@unknown"
+          },
+          {
+            "nodeId": "unknown:checker-qual-6b83e4a33220272c3a08991498ba9dc09519f190@unknown"
+          },
+          {
+            "nodeId": "unknown:error_prone_annotations-562d366678b89ce5d6b6b82c1a073880341e3fba@unknown"
+          },
+          {
+            "nodeId": "unknown:j2objc-annotations-ba035118bc8bac37d7eff77700720999acd9986d@unknown"
+          }
+        ]
+      },
+      {
+        "nodeId": "unknown:failureaccess-1dcf1de382a0bf95a3d8b0849546c88bac1292c9@unknown",
+        "pkgId": "unknown:failureaccess-1dcf1de382a0bf95a3d8b0849546c88bac1292c9@unknown",
+        "deps": []
+      },
+      {
+        "nodeId": "unknown:listenablefuture-b421526c5f297295adef1c886e5246c39d4ac629@unknown",
+        "pkgId": "unknown:listenablefuture-b421526c5f297295adef1c886e5246c39d4ac629@unknown",
+        "deps": []
+      },
+      {
+        "nodeId": "unknown:jsr305-25ea2e8b0c338a877313bd4672d3fe056ea78f0d@unknown",
+        "pkgId": "unknown:jsr305-25ea2e8b0c338a877313bd4672d3fe056ea78f0d@unknown",
+        "deps": []
+      },
+      {
+        "nodeId": "unknown:checker-qual-6b83e4a33220272c3a08991498ba9dc09519f190@unknown",
+        "pkgId": "unknown:checker-qual-6b83e4a33220272c3a08991498ba9dc09519f190@unknown",
+        "deps": []
+      },
+      {
+        "nodeId": "unknown:error_prone_annotations-562d366678b89ce5d6b6b82c1a073880341e3fba@unknown",
+        "pkgId": "unknown:error_prone_annotations-562d366678b89ce5d6b6b82c1a073880341e3fba@unknown",
+        "deps": []
+      },
+      {
+        "nodeId": "unknown:j2objc-annotations-ba035118bc8bac37d7eff77700720999acd9986d@unknown",
+        "pkgId": "unknown:j2objc-annotations-ba035118bc8bac37d7eff77700720999acd9986d@unknown",
         "deps": []
       }
     ]

--- a/test/functional/graph.spec.ts
+++ b/test/functional/graph.spec.ts
@@ -95,6 +95,42 @@ describe('buildGraph', () => {
     expected.connectDep('c@1', 'b@1:pruned');
     expect(received.equals(expected.build())).toBe(true);
   });
+  it('returns expected graph with coordinate map', async () => {
+    const received = await buildGraph(
+      {
+        'com.private:a@1': {
+          name: 'a',
+          version: '1',
+          parentIds: ['root-node'],
+        },
+        'com.public:b@1': {
+          name: 'com.public:b',
+          version: '1',
+          parentIds: ['com.private:a@1'],
+        },
+      },
+      'project',
+      '1.2.3',
+      {
+        'com.private:a@1': 'unknown:a@unknown',
+      },
+    );
+    const expected = new DepGraphBuilder(
+      { name: 'gradle' },
+      { name: 'project', version: '1.2.3' },
+    );
+    expected.addPkgNode(
+      { name: 'unknown:a', version: 'unknown' },
+      'unknown:a@unknown',
+    );
+    expected.connectDep(expected.rootNodeId, 'unknown:a@unknown');
+    expected.addPkgNode(
+      { name: 'com.public:b', version: '1' },
+      'com.public:b@1',
+    );
+    expected.connectDep('unknown:a@unknown', 'com.public:b@1');
+    expect(received.equals(expected.build())).toBe(true);
+  });
 });
 
 describe('findChildren', () => {


### PR DESCRIPTION
Discovered a bug in the graph builder when using a coordinate map.

The id used to query the snykGraph needs to be the original id, not the id from the coordinate map.

We should have noticed in the test that chops off the transitive line abruptly. Now test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json includes the full graph, even when resolution fails.
