### PR TITLE
feat: [SUP-2164] Change dependency graph root name logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,25 @@ commands:
   install_sdkman:
     description: Install SDKMAN
     steps:
+      - restore_cache:
+          name: Restore SDKMan executable
+          keys:
+            - sdkman-cli-{{ arch }}-v1
       - run:
           name: Installing SDKMAN
           command: |
-            curl -s "https://get.sdkman.io?rcupdate=false" | bash
+            if ! command -v sdk &> /dev/null
+            then
+              curl -s "https://get.sdkman.io?rcupdate=false" | bash
+            fi
+            
             echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
             source $BASH_ENV
             sdk list java
+      - save_cache:
+          key: sdkman-cli-{{ arch }}-v1
+          paths:
+            - ~/.sdkman
   install_gradle_unix:
     description: Install gradle
     parameters:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/fixtures/**/build
 npm-debug.log
 .DS_Store
 coverage
+.idea/
 
-# Diagnostic reports (https://nodejs.org/api/report.html) 
+# Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -17,7 +17,7 @@ interface QueueItem {
 
 export async function buildGraph(
   snykGraph: SnykGraph,
-  projectName: string,
+  rootPkgName: string,
   projectVersion: string,
   coordinateMap?: CoordinateMap,
 ) {
@@ -25,7 +25,7 @@ export async function buildGraph(
   const isEmptyGraph = !snykGraph || Object.keys(snykGraph).length === 0;
 
   const depGraphBuilder = new DepGraphBuilder(pkgManager, {
-    name: projectName,
+    name: rootPkgName,
     version: projectVersion || '0.0.0',
   });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,19 +6,14 @@ import * as tmp from 'tmp';
 import * as pMap from 'p-map';
 import * as chalk from 'chalk';
 import { DepGraph } from '@snyk/dep-graph';
-import debugModule = require('debug');
 import { legacyCommon, legacyPlugin as api } from '@snyk/cli-interface';
 
 import { MissingSubProjectError } from './errors';
 import { getGradleAttributesPretty } from './gradle-attributes-pretty';
 import { buildGraph, SnykGraph } from './graph';
-import type {
-  CoordinateMap,
-  PomCoords,
-  Sha1Map,
-  SnykHttpClient,
-} from './types';
+import type { CoordinateMap, PomCoords, Sha1Map, SnykHttpClient, } from './types';
 import { getMavenPackageInfo } from './search';
+import debugModule = require('debug');
 
 type ScannedProject = legacyCommon.ScannedProject;
 
@@ -98,12 +93,12 @@ export async function inspect(
 ): Promise<api.InspectResult> {
   debugLog(
     'Gradle inspect called with: ' +
-      JSON.stringify({
-        root,
-        targetFile,
-        allSubProjects: (options as any)?.allSubProjects,
-        subProject: (options as any)?.subProject,
-      }),
+    JSON.stringify({
+      root,
+      targetFile,
+      allSubProjects: (options as any)?.allSubProjects,
+      subProject: (options as any)?.subProject,
+    }),
   );
 
   if (!options) {
@@ -216,13 +211,13 @@ function extractJsonFromScriptOutput(stdoutText: string): JsonDepsScriptResult {
   if (jsonLine === null) {
     throw new Error(
       'No line prefixed with "JSONDEPS " was returned; full output:\n' +
-        stdoutText,
+      stdoutText,
     );
   }
   debugLog(
     'The command produced JSONDEPS output of ' +
-      jsonLine!.length +
-      ' characters',
+    jsonLine!.length +
+    ' characters',
   );
   return JSON.parse(jsonLine!);
 }
@@ -527,7 +522,6 @@ async function getAllDeps(
       });
     }
     return await processProjectsInExtractedJSON(
-      root,
       extractedJSON,
       coordinateMap,
     );
@@ -568,8 +562,8 @@ You have several options to make dependency resolution rules more specific:
 
 1. Run Snyk CLI tool with an attribute filter, e.g.:
     ${chalk.whiteBright(
-      'snyk test --all-sub-projects --configuration-attributes=buildtype:release,usage:java-runtime',
-    )}
+        'snyk test --all-sub-projects --configuration-attributes=buildtype:release,usage:java-runtime',
+      )}
 
 The filter will select matching attributes from those found in your configurations, use them
 to select matching configuration(s) to be used to resolve dependencies. Any sub-string of the full
@@ -586,8 +580,8 @@ ${jsonAttrsPretty}
 
 2. Run Snyk CLI tool for specific configuration(s), e.g.:
     ${chalk.whiteBright(
-      "snyk test --gradle-sub-project=my-app --configuration-matching='^releaseRuntimeClasspath$'",
-    )}
+        "snyk test --gradle-sub-project=my-app --configuration-matching='^releaseRuntimeClasspath$'",
+      )}
 
 (note that some configurations won't be present in every your subproject)
 
@@ -595,8 +589,8 @@ ${jsonAttrsPretty}
     ${chalk.whiteBright("implementation project(':mymodule')")}
 to
     ${chalk.whiteBright(
-      "implementation project(path: ':mymodule', configuration: 'default')",
-    )}`;
+        "implementation project(path: ':mymodule', configuration: 'default')",
+      )}`;
     }
 
     error.message = `${chalk.red.bold(
@@ -614,7 +608,6 @@ ${chalk.red.bold(mainErrorMessage)}`;
 }
 
 export async function processProjectsInExtractedJSON(
-  root: string,
   extractedJSON: JsonDepsScriptResult,
   coordinateMap?: CoordinateMap,
 ) {
@@ -626,16 +619,11 @@ export async function processProjectsInExtractedJSON(
       continue;
     }
 
-    const invalidValues = [null, undefined, ''];
-    const isValidRootDir = invalidValues.indexOf(root) === -1;
     const isSubProject = projectId !== defaultProjectKey;
 
-    let projectName = isValidRootDir ? path.basename(root) : defaultProject;
-
+    let projectName = defaultProject;
     if (isSubProject) {
-      projectName = isValidRootDir
-        ? `${path.basename(root)}/${projectId}`
-        : `${defaultProject}/${projectId}`;
+      projectName = `${defaultProject}/${projectId}`;
     }
 
     extractedJSON.projects[projectId].depGraph = await buildGraph(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -623,14 +623,14 @@ export async function processProjectsInExtractedJSON(
 
     const isSubProject = projectId !== defaultProjectKey;
 
-    let projectName = defaultProject;
+    let rootPkgName = defaultProject;
     if (isSubProject) {
-      projectName = `${defaultProject}/${projectId}`;
+      rootPkgName = `${defaultProject}/${projectId}`;
     }
 
     extractedJSON.projects[projectId].depGraph = await buildGraph(
       snykGraph,
-      projectName,
+      rootPkgName,
       projectVersion,
       coordinateMap,
     );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,12 @@ import { legacyCommon, legacyPlugin as api } from '@snyk/cli-interface';
 import { MissingSubProjectError } from './errors';
 import { getGradleAttributesPretty } from './gradle-attributes-pretty';
 import { buildGraph, SnykGraph } from './graph';
-import type { CoordinateMap, PomCoords, Sha1Map, SnykHttpClient, } from './types';
+import type {
+  CoordinateMap,
+  PomCoords,
+  Sha1Map,
+  SnykHttpClient,
+} from './types';
 import { getMavenPackageInfo } from './search';
 import debugModule = require('debug');
 
@@ -93,12 +98,12 @@ export async function inspect(
 ): Promise<api.InspectResult> {
   debugLog(
     'Gradle inspect called with: ' +
-    JSON.stringify({
-      root,
-      targetFile,
-      allSubProjects: (options as any)?.allSubProjects,
-      subProject: (options as any)?.subProject,
-    }),
+      JSON.stringify({
+        root,
+        targetFile,
+        allSubProjects: (options as any)?.allSubProjects,
+        subProject: (options as any)?.subProject,
+      }),
   );
 
   if (!options) {
@@ -211,13 +216,13 @@ function extractJsonFromScriptOutput(stdoutText: string): JsonDepsScriptResult {
   if (jsonLine === null) {
     throw new Error(
       'No line prefixed with "JSONDEPS " was returned; full output:\n' +
-      stdoutText,
+        stdoutText,
     );
   }
   debugLog(
     'The command produced JSONDEPS output of ' +
-    jsonLine!.length +
-    ' characters',
+      jsonLine!.length +
+      ' characters',
   );
   return JSON.parse(jsonLine!);
 }
@@ -521,10 +526,7 @@ async function getAllDeps(
         concurrency: 100,
       });
     }
-    return await processProjectsInExtractedJSON(
-      extractedJSON,
-      coordinateMap,
-    );
+    return await processProjectsInExtractedJSON(extractedJSON, coordinateMap);
   } catch (err) {
     const error: Error = err;
     const gradleErrorMarkers = /^\s*>\s.*$/;
@@ -562,8 +564,8 @@ You have several options to make dependency resolution rules more specific:
 
 1. Run Snyk CLI tool with an attribute filter, e.g.:
     ${chalk.whiteBright(
-        'snyk test --all-sub-projects --configuration-attributes=buildtype:release,usage:java-runtime',
-      )}
+      'snyk test --all-sub-projects --configuration-attributes=buildtype:release,usage:java-runtime',
+    )}
 
 The filter will select matching attributes from those found in your configurations, use them
 to select matching configuration(s) to be used to resolve dependencies. Any sub-string of the full
@@ -580,8 +582,8 @@ ${jsonAttrsPretty}
 
 2. Run Snyk CLI tool for specific configuration(s), e.g.:
     ${chalk.whiteBright(
-        "snyk test --gradle-sub-project=my-app --configuration-matching='^releaseRuntimeClasspath$'",
-      )}
+      "snyk test --gradle-sub-project=my-app --configuration-matching='^releaseRuntimeClasspath$'",
+    )}
 
 (note that some configurations won't be present in every your subproject)
 
@@ -589,8 +591,8 @@ ${jsonAttrsPretty}
     ${chalk.whiteBright("implementation project(':mymodule')")}
 to
     ${chalk.whiteBright(
-        "implementation project(path: ':mymodule', configuration: 'default')",
-      )}`;
+      "implementation project(path: ':mymodule', configuration: 'default')",
+    )}`;
     }
 
     error.message = `${chalk.red.bold(

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --color --cache '{lib,test}/**/*.{js,ts}' && prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "tsc -p tsconfig-test.json && jest -b --maxWorkers=2 --testTimeout=150000"
+    "test": "tsc -p tsconfig-test.json && jest --maxWorkers=2 --testTimeout=150000"
   },
   "author": "snyk.io",
   "license": "Apache-2.0",

--- a/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
+++ b/test/fixtures-with-wrappers/basic-with-deps/dep-graph-gradleNormalizeDeps-failed-search.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "basic-with-deps@unspecified",
       "info": {
-        "name": ".",
+        "name": "basic-with-deps",
         "version": "unspecified"
       }
     },
@@ -66,7 +66,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "basic-with-deps@unspecified",
         "deps": [
           {
             "nodeId": "unknown:guava-87e0fd1df874ea3cbe577702fe6f17068b790fd8@unknown"

--- a/test/fixtures-with-wrappers/basic-with-deps/dep-graph.json
+++ b/test/fixtures-with-wrappers/basic-with-deps/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "basic-with-deps@unspecified",
       "info": {
-        "name": ".",
+        "name": "basic-with-deps",
         "version": "unspecified"
       }
     },
@@ -66,7 +66,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "basic-with-deps@unspecified",
         "deps": [
           {
             "nodeId": "com.google.guava:guava@30.1.1-jre"

--- a/test/fixtures-with-wrappers/basic-with-failed-dep/dep-graph.json
+++ b/test/fixtures-with-wrappers/basic-with-failed-dep/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "basic-with-failed-dep@unspecified",
       "info": {
-        "name": ".",
+        "name": "basic-with-failed-dep",
         "version": "unspecified"
       }
     },
@@ -66,7 +66,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "basic-with-failed-dep@unspecified",
         "deps": [
           {
             "nodeId": "com.google.guava:guava@30.1.1-jre"

--- a/test/fixtures-with-wrappers/configuration-consistency/dep-graph.json
+++ b/test/fixtures-with-wrappers/configuration-consistency/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "configuration-consistency@unspecified",
       "info": {
-        "name": ".",
+        "name": "configuration-consistency",
         "version": "unspecified"
       }
     },
@@ -73,7 +73,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "configuration-consistency@unspecified",
         "deps": [
           {
             "nodeId": "org.codehaus.groovy:groovy@3.0.1"

--- a/test/fixtures-with-wrappers/custom-configuration/dep-graph.json
+++ b/test/fixtures-with-wrappers/custom-configuration/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "custom-configuration@unspecified",
       "info": {
-        "name": ".",
+        "name": "custom-configuration",
         "version": "unspecified"
       }
     },
@@ -38,7 +38,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "custom-configuration@unspecified",
         "deps": [
           {
             "nodeId": "org.mockito:mockito-core@4.6.1"

--- a/test/fixtures-with-wrappers/empty-build-gradle-in-root/dep-graph.json
+++ b/test/fixtures-with-wrappers/empty-build-gradle-in-root/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "no-build-gradle-in-root@unspecified",
       "info": {
-        "name": ".",
+        "name": "no-build-gradle-in-root",
         "version": "unspecified"
       }
     }
@@ -17,7 +17,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "no-build-gradle-in-root@unspecified",
         "deps": []
       }
     ]

--- a/test/fixtures-with-wrappers/empty-project/dep-graph.json
+++ b/test/fixtures-with-wrappers/empty-project/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "basic@unspecified",
       "info": {
-        "name": ".",
+        "name": "basic",
         "version": "unspecified"
       }
     }
@@ -17,7 +17,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "basic@unspecified",
         "deps": []
       }
     ]

--- a/test/fixtures-with-wrappers/kts-basic-with-deps/dep-graph.json
+++ b/test/fixtures-with-wrappers/kts-basic-with-deps/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@1.0.0-SNAPSHOT",
+      "id": "kts-basic-with-deps@1.0.0-SNAPSHOT",
       "info": {
-        "name": ".",
+        "name": "kts-basic-with-deps",
         "version": "1.0.0-SNAPSHOT"
       }
     },
@@ -101,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@1.0.0-SNAPSHOT",
+        "pkgId": "kts-basic-with-deps@1.0.0-SNAPSHOT",
         "deps": [
           {
             "nodeId": "org.jetbrains.kotlin:kotlin-stdlib-jdk8@1.3.21"

--- a/test/fixtures-with-wrappers/kts-configuration-consistency/dep-graph.json
+++ b/test/fixtures-with-wrappers/kts-configuration-consistency/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@1.0.0-SNAPSHOT",
+      "id": "kts-configuration-consistency@1.0.0-SNAPSHOT",
       "info": {
-        "name": ".",
+        "name": "kts-configuration-consistency",
         "version": "1.0.0-SNAPSHOT"
       }
     },
@@ -101,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@1.0.0-SNAPSHOT",
+        "pkgId": "kts-configuration-consistency@1.0.0-SNAPSHOT",
         "deps": [
           {
             "nodeId": "org.jetbrains.kotlin:kotlin-stdlib-jdk8@1.3.21"

--- a/test/fixtures-with-wrappers/kts-strict-lock-mode/dep-graph.json
+++ b/test/fixtures-with-wrappers/kts-strict-lock-mode/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@1.0.0-SNAPSHOT",
+      "id": "kts-strict-lock-mode@1.0.0-SNAPSHOT",
       "info": {
-        "name": ".",
+        "name": "kts-strict-lock-mode",
         "version": "1.0.0-SNAPSHOT"
       }
     },
@@ -101,7 +101,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@1.0.0-SNAPSHOT",
+        "pkgId": "kts-strict-lock-mode@1.0.0-SNAPSHOT",
         "deps": [
           {
             "nodeId": "org.jetbrains.kotlin:kotlin-stdlib-jdk8@1.3.21"

--- a/test/fixtures-with-wrappers/kts-version-catalog-module/dep-graph.json
+++ b/test/fixtures-with-wrappers/kts-version-catalog-module/dep-graph.json
@@ -1,13 +1,13 @@
 {
   "graph": {
-    "nodes": [{ "deps": [], "nodeId": "root-node", "pkgId": ".@1.0" }],
+    "nodes": [{ "deps": [], "nodeId": "root-node", "pkgId": "kts-version-catalog-module@1.0" }],
     "rootNodeId": "root-node"
   },
   "pkgManager": { "name": "gradle" },
   "pkgs": [
     {
-      "id": ".@1.0",
-      "info": { "name": ".", "version": "1.0" }
+      "id": "kts-version-catalog-module@1.0",
+      "info": { "name": "kts-version-catalog-module", "version": "1.0" }
     }
   ],
   "schemaVersion": "1.2.0"

--- a/test/fixtures-with-wrappers/platform-project-mvn-bom/dep-graph.json
+++ b/test/fixtures-with-wrappers/platform-project-mvn-bom/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "platform-project-mvn-bom@unspecified",
       "info": {
-        "name": ".",
+        "name": "platform-project-mvn-bom",
         "version": "unspecified"
       }
     },
@@ -45,7 +45,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "platform-project-mvn-bom@unspecified",
         "deps": [
           {
             "nodeId": "org.springframework.boot:spring-boot-dependencies@1.5.8.RELEASE"

--- a/test/fixtures-with-wrappers/repo-content-filtering/dep-graph.json
+++ b/test/fixtures-with-wrappers/repo-content-filtering/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "repo-content-filtering@unspecified",
       "info": {
-        "name": ".",
+        "name": "repo-content-filtering",
         "version": "unspecified"
       }
     },
@@ -80,7 +80,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "repo-content-filtering@unspecified",
         "deps": [
           {
             "nodeId": "com.google.guava:guava@30.1.1-jre"

--- a/test/fixtures-with-wrappers/version-catalog-settings/dep-graph.json
+++ b/test/fixtures-with-wrappers/version-catalog-settings/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "version-catalogues@unspecified",
       "info": {
-        "name": ".",
+        "name": "version-catalogues",
         "version": "unspecified"
       }
     },
@@ -38,7 +38,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "version-catalogues@unspecified",
         "deps": [
           {
             "nodeId": "org.codehaus.groovy:groovy@3.0.5"

--- a/test/fixtures-with-wrappers/version-catalog-toml/dep-graph.json
+++ b/test/fixtures-with-wrappers/version-catalog-toml/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "version-catalog-toml@unspecified",
       "info": {
-        "name": ".",
+        "name": "version-catalog-toml",
         "version": "unspecified"
       }
     },
@@ -94,7 +94,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "version-catalog-toml@unspecified",
         "deps": [
           {
             "nodeId": "org.mockito:mockito-core@4.5.1"

--- a/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
+++ b/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "with-lock-file@unspecified",
       "info": {
-        "name": ".",
+        "name": "with-lock-file",
         "version": "unspecified"
       }
     },
@@ -73,7 +73,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "with-lock-file@unspecified",
         "deps": [
           {
             "nodeId": "org.codehaus.groovy:groovy@3.0.3"

--- a/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
+++ b/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
@@ -19,6 +19,13 @@
       }
     },
     {
+      "id": "com.google.guava:guava@32.1.3-jre",
+      "info": {
+        "name": "com.google.guava:guava",
+        "version": "32.1.3-jre"
+      }
+    },
+    {
       "id": "com.google.guava:guava@31.1-jre",
       "info": {
         "name": "com.google.guava:guava",
@@ -47,10 +54,17 @@
       }
     },
     {
-      "id": "org.checkerframework:checker-qual@3.12.0",
+      "id": "org.checkerframework:checker-qual@3.37.0",
       "info": {
         "name": "org.checkerframework:checker-qual",
-        "version": "3.12.0"
+        "version": "3.37.0"
+      }
+    },
+    {
+      "id": "com.google.errorprone:error_prone_annotations@2.21.1",
+      "info": {
+        "name": "com.google.errorprone:error_prone_annotations",
+        "version": "2.21.1"
       }
     },
     {
@@ -58,6 +72,13 @@
       "info": {
         "name": "com.google.errorprone:error_prone_annotations",
         "version": "2.11.0"
+      }
+    },
+    {
+      "id": "org.checkerframework:checker-qual@3.12.0",
+      "info": {
+        "name": "org.checkerframework:checker-qual",
+        "version": "3.12.0"
       }
     },
     {
@@ -79,6 +100,9 @@
             "nodeId": "org.codehaus.groovy:groovy@3.0.3"
           },
           {
+            "nodeId": "com.google.guava:guava@32.1.3-jre"
+          },
+          {
             "nodeId": "com.google.guava:guava@31.1-jre"
           }
         ]
@@ -89,8 +113,8 @@
         "deps": []
       },
       {
-        "nodeId": "com.google.guava:guava@31.1-jre",
-        "pkgId": "com.google.guava:guava@31.1-jre",
+        "nodeId": "com.google.guava:guava@32.1.3-jre",
+        "pkgId": "com.google.guava:guava@32.1.3-jre",
         "deps": [
           {
             "nodeId": "com.google.guava:failureaccess@1.0.1"
@@ -102,10 +126,31 @@
             "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
           },
           {
-            "nodeId": "org.checkerframework:checker-qual@3.12.0"
+            "nodeId": "org.checkerframework:checker-qual@3.37.0"
+          },
+          {
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.21.1"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.google.guava:guava@31.1-jre",
+        "pkgId": "com.google.guava:guava@31.1-jre",
+        "deps": [
+          {
+            "nodeId": "com.google.guava:failureaccess@1.0.1:pruned"
+          },
+          {
+            "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned"
+          },
+          {
+            "nodeId": "com.google.code.findbugs:jsr305@3.0.2:pruned"
           },
           {
             "nodeId": "com.google.errorprone:error_prone_annotations@2.11.0"
+          },
+          {
+            "nodeId": "org.checkerframework:checker-qual@3.12.0"
           },
           {
             "nodeId": "com.google.j2objc:j2objc-annotations@1.3"
@@ -128,13 +173,53 @@
         "deps": []
       },
       {
-        "nodeId": "org.checkerframework:checker-qual@3.12.0",
-        "pkgId": "org.checkerframework:checker-qual@3.12.0",
+        "nodeId": "org.checkerframework:checker-qual@3.37.0",
+        "pkgId": "org.checkerframework:checker-qual@3.37.0",
         "deps": []
+      },
+      {
+        "nodeId": "com.google.errorprone:error_prone_annotations@2.21.1",
+        "pkgId": "com.google.errorprone:error_prone_annotations@2.21.1",
+        "deps": []
+      },
+      {
+        "nodeId": "com.google.guava:failureaccess@1.0.1:pruned",
+        "pkgId": "com.google.guava:failureaccess@1.0.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned",
+        "pkgId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
+      },
+      {
+        "nodeId": "com.google.code.findbugs:jsr305@3.0.2:pruned",
+        "pkgId": "com.google.code.findbugs:jsr305@3.0.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "true"
+          }
+        }
       },
       {
         "nodeId": "com.google.errorprone:error_prone_annotations@2.11.0",
         "pkgId": "com.google.errorprone:error_prone_annotations@2.11.0",
+        "deps": []
+      },
+      {
+        "nodeId": "org.checkerframework:checker-qual@3.12.0",
+        "pkgId": "org.checkerframework:checker-qual@3.12.0",
         "deps": []
       },
       {

--- a/test/fixtures/pruned-spring-app/dep-graph.json
+++ b/test/fixtures/pruned-spring-app/dep-graph.json
@@ -5,9 +5,9 @@
   },
   "pkgs": [
     {
-      "id": ".@unspecified",
+      "id": "pruned-spring-app@unspecified",
       "info": {
-        "name": ".",
+        "name": "pruned-spring-app",
         "version": "unspecified"
       }
     },
@@ -45,7 +45,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": ".@unspecified",
+        "pkgId": "pruned-spring-app@unspecified",
         "deps": [
           {
             "nodeId": "org.springframework:spring-web@5.3.10"

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -39,7 +39,6 @@ describe('findProjectsInExtractedJSON', () => {
 
       const { defaultProject, projects, allSubProjectNames } =
         await processProjectsInExtractedJSON(
-          rootDir,
           jsonExtractedFromGradleStdout,
         );
 

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -5,14 +5,14 @@ describe('findProjectsInExtractedJSON', () => {
   const fakeRootDir = path.join('dev', 'tardis-master');
 
   it.each`
-    rootDir        | targetFile
-    ${''}          | ${'build.gradle'}
-    ${null}        | ${'build.gradle'}
-    ${undefined}   | ${'build.gradle'}
-    ${fakeRootDir} | ${path.join(fakeRootDir, 'build.gradle')}
+    targetFile
+    ${'build.gradle'}
+    ${'build.gradle'}
+    ${'build.gradle'}
+    ${path.join(fakeRootDir, 'build.gradle')}
   `(
     'project with targetFile `$targetFile` have valid name when rootDir is `$rootDir`',
-    async ({ rootDir, targetFile }) => {
+    async ({ targetFile }) => {
       const jsonExtractedFromGradleStdout = {
         defaultProject: 'tardis-master',
         defaultProjectKey: 'tardis-master',

--- a/test/manual/gradle-stdout.spec.ts
+++ b/test/manual/gradle-stdout.spec.ts
@@ -38,9 +38,7 @@ describe('findProjectsInExtractedJSON', () => {
       };
 
       const { defaultProject, projects, allSubProjectNames } =
-        await processProjectsInExtractedJSON(
-          jsonExtractedFromGradleStdout,
-        );
+        await processProjectsInExtractedJSON(jsonExtractedFromGradleStdout);
 
       expect(defaultProject).toEqual('tardis-master');
       expect(projects['tardis-master']?.targetFile).toEqual(`${targetFile}`);

--- a/test/system/fixtures-with-wrappers.test.ts
+++ b/test/system/fixtures-with-wrappers.test.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { createFromJSON } from '@snyk/dep-graph';
 import { NeedleResponse } from 'needle';
 
 import { getPathToFixture } from '../common';
@@ -26,15 +25,10 @@ describe('inspect() fixtures', () => {
       const buildFileName = isKotlin ? 'build.gradle.kts' : 'build.gradle';
       const pathToBuildConfig = path.join(fixturePath, buildFileName);
       const expectedDepGraphJson = require(`${fixturePath}/dep-graph.json`);
-      const expectedDepGraph = createFromJSON(expectedDepGraphJson);
 
       const result = await inspect('.', pathToBuildConfig);
 
-      const resultMatchesExpected =
-        result.dependencyGraph &&
-        expectedDepGraph.equals(result.dependencyGraph);
-
-      expect(resultMatchesExpected).toBeTruthy();
+      expect(result.dependencyGraph.toJSON()).toEqual(expectedDepGraphJson);
     }, 100000);
   });
 
@@ -56,17 +50,12 @@ describe('inspect() fixtures', () => {
       const buildFileName = isKotlin ? 'build.gradle.kts' : 'build.gradle';
       const pathToBuildConfig = path.join(fixturePath, buildFileName);
       const expectedDepGraphJson = require(`${fixturePath}/dep-graph.json`);
-      const expectedDepGraph = createFromJSON(expectedDepGraphJson);
 
       const result = await inspect('.', pathToBuildConfig, {
         gradleNormalizeDeps: true,
       });
 
-      const resultMatchesExpected =
-        result.dependencyGraph &&
-        expectedDepGraph.equals(result.dependencyGraph);
-
-      expect(resultMatchesExpected).toBeTruthy();
+      expect(result.dependencyGraph.toJSON()).toEqual(expectedDepGraphJson);
     }, 100000);
   });
 
@@ -97,17 +86,12 @@ describe('inspect() fixtures', () => {
       const buildFileName = isKotlin ? 'build.gradle.kts' : 'build.gradle';
       const pathToBuildConfig = path.join(fixturePath, buildFileName);
       const expectedDepGraphJson = require(`${fixturePath}/dep-graph-gradleNormalizeDeps-failed-search.json`);
-      const expectedDepGraph = createFromJSON(expectedDepGraphJson);
 
       const result = await inspect('.', pathToBuildConfig, {
         gradleNormalizeDeps: true,
       });
 
-      const resultMatchesExpected =
-        result.dependencyGraph &&
-        expectedDepGraph.equals(result.dependencyGraph);
-
-      expect(resultMatchesExpected).toBeTruthy();
+      expect(result.dependencyGraph.toJSON()).toEqual(expectedDepGraphJson);
     }, 100000);
   });
 });

--- a/test/system/kotlin.test.ts
+++ b/test/system/kotlin.test.ts
@@ -15,7 +15,7 @@ if (isKotlinSupported) {
       '.',
       path.join(fixtureDir('gradle-kts'), 'build.gradle.kts'),
     );
-    expect(result.dependencyGraph.rootPkg.name).toMatch('.');
+    expect(result.dependencyGraph.rootPkg.name).toMatch('gradle-kts');
     expect(result.meta!.gradleProjectName).toMatch('gradle-kts');
     const pkgs = result.dependencyGraph.getDepPkgs();
     const nodeIds: string[] = [];

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -27,7 +27,7 @@ test('multi-project, explicitly targeting a subproject build file', async () => 
 
 test('multi-project, ran from root, targeting subproj', async () => {
   const result = await inspect(multiProject, 'subproj/build.gradle');
-    expect(result.dependencyGraph.rootPkg.name).toBe('subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe('subproj');
   expect(result.meta!.gradleProjectName).toBe('subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([]);
 
@@ -71,7 +71,7 @@ test('multi-project: only sub-project has deps and they are returned', async () 
     path.join(multiProject, 'build.gradle'),
     options,
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('./subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj/subproj');
   expect(result.meta!.gradleProjectName).toBe('root-proj/subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual(['subproj']);
 
@@ -175,7 +175,7 @@ test('multi-project: deps for both projects are returned with allSubProjects fla
   // It's an array, so we have to scan
   expect(result.scannedProjects.length).toBe(2);
   for (const p of result.scannedProjects) {
-    if (p.depGraph.rootPkg.name === '.') {
+    if (p.depGraph.rootPkg.name === 'root-proj') {
       expect(p.meta!.gradleProjectName).toBe('root-proj');
       // double parsing to have access to internal depGraph data, no methods available to properly
       // return the deps nodeIds list that belongs to a node
@@ -185,7 +185,7 @@ test('multi-project: deps for both projects are returned with allSubProjects fla
       // TODO(kyegupov): when the project name issue is solved, change the assertion to:
       // expect(p.targetFile, 'multi-project' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
     } else {
-      expect(p.depGraph.rootPkg.name).toBe('./subproj');
+      expect(p.depGraph.rootPkg.name).toBe('root-proj/subproj');
       expect(p.meta!.gradleProjectName).toBe('root-proj/subproj');
 
       const pkgs = p.depGraph.getDepPkgs();
@@ -212,7 +212,9 @@ test('single-project: array of one is returned with allSubProjects flag', async 
     { allSubProjects: true },
   );
   expect(result.scannedProjects.length).toBe(1);
-  expect(result.scannedProjects[0].depGraph.rootPkg.name).toBe('.');
+  expect(result.scannedProjects[0].depGraph.rootPkg.name).toBe(
+    'api-configuration',
+  );
   expect(result.scannedProjects[0].meta!.gradleProjectName).toBe(
     'api-configuration',
   );
@@ -282,12 +284,12 @@ test('multi-project: parallel with allSubProjects produces multiple results with
   }
   expect(names).toEqual(
     new Set<string>([
-      'multi-project-parallel',
-      'multi-project-parallel/subproj0',
-      'multi-project-parallel/subproj1',
-      'multi-project-parallel/subproj2',
-      'multi-project-parallel/subproj3',
-      'multi-project-parallel/subproj4',
+      'root-proj',
+      'root-proj/subproj0',
+      'root-proj/subproj1',
+      'root-proj/subproj2',
+      'root-proj/subproj3',
+      'root-proj/subproj4',
     ]),
   );
   expect(newNames).toEqual(
@@ -310,7 +312,7 @@ test('multi-project: allSubProjects + configuration', async () => {
   // It's an array, so we have to scan
   expect(result.scannedProjects.length).toBe(2);
   for (const p of result.scannedProjects) {
-    if (p.depGraph.rootPkg.name === '.') {
+    if (p.depGraph.rootPkg.name === 'root-proj') {
       expect(p.meta!.gradleProjectName).toBe('root-proj');
 
       // double parsing to have access to internal depGraph data, no methods available to properly
@@ -323,7 +325,7 @@ test('multi-project: allSubProjects + configuration', async () => {
       // expect(p.targetFile, 'multi-project' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
     } else {
       // sub project name is included in the root pkg name
-      expect(p.depGraph.rootPkg.name).toBe('./subproj');
+      expect(p.depGraph.rootPkg.name).toBe('root-proj/subproj');
       // new sub project name is included in the root pkg name
       expect(p.meta!.gradleProjectName).toBe('root-proj/subproj');
 
@@ -376,7 +378,7 @@ test('multi-project-dependency-cycle: scanning all subprojects works fine', asyn
   expect(result.scannedProjects.length).toBe(2);
 
   for (const p of result.scannedProjects) {
-    if (p.depGraph.rootPkg.name === '.') {
+    if (p.depGraph.rootPkg.name === 'root-proj') {
       expect(p.meta!.gradleProjectName).toBe('root-proj');
       // double parsing to have access to internal depGraph data, no methods available to properly
       // return the deps nodeIds list that belongs to a node
@@ -570,7 +572,9 @@ test('multi-project: correct deps for subproject with the same name, one depende
     { subProject: 'subproj' },
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('subprojects-same-name/subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe(
+    'subprojects-same-name/subproj',
+  );
   expect(result.meta!.gradleProjectName).toBe('subprojects-same-name/subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([
     'greeter',
@@ -601,7 +605,9 @@ test('multi-project: correct deps for a nested subproject using --sub-project', 
     { subProject: 'lib' },
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('gradle-sandbox/greeter/lib');
+  expect(result.dependencyGraph.rootPkg.name).toBe(
+    'gradle-sandbox/greeter/lib',
+  );
   expect(result.meta!.gradleProjectName).toBe('gradle-sandbox/greeter/lib');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([
     'greeter',

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -10,7 +10,7 @@ test('multi-project, explicitly targeting a subproject build file', async () => 
     '.',
     path.join(multiProject, 'subproj', 'build.gradle'),
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('subproj');
   expect(result.meta!.gradleProjectName).toBe('subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([]);
 
@@ -27,7 +27,7 @@ test('multi-project, explicitly targeting a subproject build file', async () => 
 
 test('multi-project, ran from root, targeting subproj', async () => {
   const result = await inspect(multiProject, 'subproj/build.gradle');
-  expect(result.dependencyGraph.rootPkg.name).toBe('multi-project');
+    expect(result.dependencyGraph.rootPkg.name).toBe('subproj');
   expect(result.meta!.gradleProjectName).toBe('subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([]);
 
@@ -89,7 +89,7 @@ test('multi-project: only sub-project has deps and they are returned', async () 
 test('multi-project: only sub-project has deps, none returned for main', async () => {
   const result = await inspect('.', path.join(multiProject, 'build.gradle'));
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj');
 
   expect(result.meta!.gradleProjectName).toBe('root-proj');
 
@@ -117,7 +117,7 @@ if (wrapperIsCompatibleWithJvm) {
       '.',
       path.join(fixtureDir('multi-project gradle wrapper'), 'build.gradle'),
     );
-    expect(result.dependencyGraph.rootPkg.name).toBe('.');
+    expect(result.dependencyGraph.rootPkg.name).toBe('root-proj');
     expect(result.meta!.gradleProjectName).toBe('root-proj');
     expect(result.meta!.versionBuildInfo!.gradleVersion).toBe('5.4.1');
     expect(result.plugin.meta!.allSubProjectNames).toEqual(['subproj']);
@@ -134,7 +134,7 @@ test('multi-project: parallel is handled correctly', async () => {
     fixtureDir('multi-project-parallel'),
     'build.gradle',
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('multi-project-parallel');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj');
   expect(result.meta!.gradleProjectName).toBe('root-proj');
 
   // double parsing to have access to internal depGraph data, no methods available to properly
@@ -154,7 +154,7 @@ test('multi-project: only sub-project has deps and they are returned space needs
   );
 
   expect(result.plugin.meta!.allSubProjectNames).toEqual(['subproj']);
-  expect(result.dependencyGraph.rootPkg.name).toBe('./subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj/subproj');
   expect(result.meta!.gradleProjectName).toBe('root-proj/subproj');
 
   const pkgs = result.dependencyGraph.getDepPkgs();
@@ -242,7 +242,7 @@ test('multi-project-some-unscannable: gradle-sub-project for a good subproject w
     'subproj-fail',
   ]);
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('./subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj/subproj');
   expect(result.meta!.gradleProjectName).toBe('root-proj/subproj');
 
   const pkgs = result.dependencyGraph.getDepPkgs();
@@ -350,7 +350,7 @@ test('multi-project-dependency-cycle: scanning the main project works fine', asy
     path.join(fixtureDir('multi-project-dependency-cycle'), 'build.gradle'),
     {},
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('root-proj');
   expect(result.meta!.gradleProjectName).toBe('root-proj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual(['subproj']);
 
@@ -544,7 +544,7 @@ test('multi-project: correct deps for subproject with the same name, one depende
     ),
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('subproj');
   expect(result.meta!.gradleProjectName).toBe('subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([]);
 
@@ -570,7 +570,7 @@ test('multi-project: correct deps for subproject with the same name, one depende
     { subProject: 'subproj' },
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('./subproj');
+  expect(result.dependencyGraph.rootPkg.name).toBe('subprojects-same-name/subproj');
   expect(result.meta!.gradleProjectName).toBe('subprojects-same-name/subproj');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([
     'greeter',
@@ -601,7 +601,7 @@ test('multi-project: correct deps for a nested subproject using --sub-project', 
     { subProject: 'lib' },
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('./greeter/lib');
+  expect(result.dependencyGraph.rootPkg.name).toBe('gradle-sandbox/greeter/lib');
   expect(result.meta!.gradleProjectName).toBe('gradle-sandbox/greeter/lib');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([
     'greeter',
@@ -630,7 +630,7 @@ test('multi-project shadow dep: process dependencies when a shadowed dep is used
     { subProject: 'module' },
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('./module');
+  expect(result.dependencyGraph.rootPkg.name).toBe('test/module');
   expect(result.meta!.gradleProjectName).toBe('test/module');
   expect(result.plugin.meta!.allSubProjectNames).toEqual([
     'module',

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -53,7 +53,7 @@ test('multi-config: both compile and runtime deps picked up by default', async (
     path.join(fixtureDir('multi-config'), 'build.gradle'),
   );
 
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('multi-config');
   expect(result.meta!.gradleProjectName).toBe('multi-config');
 
   const pkgs = result.dependencyGraph.getDepPkgs();
@@ -83,7 +83,7 @@ test('multi-config: only deps for specified conf are picked up (precise match)',
     path.join(fixtureDir('multi-config'), 'build.gradle'),
     { 'configuration-matching': '^compileClasspath$' },
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('multi-config');
   expect(result.meta!.gradleProjectName).toBe('multi-config');
 
   const pkgs = result.dependencyGraph.getDepPkgs();
@@ -109,7 +109,7 @@ test('multi-config: only deps for specified conf are picked up (fuzzy match)', a
     path.join(fixtureDir('multi-config'), 'build.gradle'),
     { 'configuration-matching': 'pileclass' },
   ); // case-insensitive regexp matching "compileClasspath"
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('multi-config');
   expect(result.meta!.gradleProjectName).toBe('multi-config');
 
   const pkgs = result.dependencyGraph.getDepPkgs();
@@ -135,7 +135,7 @@ test('multi-config: only deps for specified conf are picked up (using legacy CLI
     path.join(fixtureDir('multi-config'), 'build.gradle'),
     { args: ['--configuration', 'compileClasspath'] },
   );
-  expect(result.dependencyGraph.rootPkg.name).toBe('.');
+  expect(result.dependencyGraph.rootPkg.name).toBe('multi-config');
   expect(result.meta!.gradleProjectName).toBe('multi-config');
   const pkgs = result.dependencyGraph.getDepPkgs();
   const nodeIds: string[] = [];

--- a/test/system/plugin.test.ts
+++ b/test/system/plugin.test.ts
@@ -193,10 +193,10 @@ test('custom dependency resolution via configurations* is supported', async () =
 
 test('repeated transitive lines terminated at duplicate node and labeled pruned', async () => {
   const pathToFixture = fixtureDir('pruned-spring-app');
-  const result = await inspect('.', path.join(pathToFixture, 'build.gradle'));
   const expectedJson = JSON.parse(
     fs.readFileSync(path.join(pathToFixture, 'dep-graph.json'), 'utf-8'),
   );
   const expected = depGraphLib.createFromJSON(expectedJson);
+  const result = await inspect('.', path.join(pathToFixture, 'build.gradle'));
   expect(result.dependencyGraph?.equals(expected)).toBe(true);
 });


### PR DESCRIPTION
### What this does

There is a discrepancy between what we call our projects and what we call our root nodes in the dependency graphs. This sounds like it should not matter, but it does.

We have a regression introduced after a bugfix was made last month, where `snyk test` now does not correctly pick up ignores in the ui after a `snyk monitor` on certain types of Gradle projects.

Doing this change will fix that.

### Problem

(Links to internal projects)

* [This](https://github.com/snyk/registry/blob/ac4373282fbc6d6a145cc9bf4fab2518e0d7b144/src/web/routes/api/v1/monitor.ts#L165-L168) is how we make a project id in `monitor`.
* [This](https://github.com/snyk/registry/blob/d078339f187dfe5b9de4789e03fa823e54bac81f/src/web/routes/api/v1/test/dep-graph.ts#L125-L130) is how we make a project id in `test`.

Since the bugfix last month, root package names no longer match the project names in Gradle projects. Doing a `--list-deps` or looking at the UI will show one name in the project name and another in the root package list.

This is the root cause of the bug why `snyk test` does not pick up changes, as the project identity that is being tested against is generated from the root package name, not the "defaultProjectName" like `snyk monitor`.

### Breaking change

I'm bumping the major version for this one, unless anybody objects. Not **technically** a breaking change, as this should not cause orphaned projects. It should merely create a new element in the history i the same project - but out of caution i find it makes sense, just to show that we're changing expected behavior. In case any consumer is relying on this value.

## Project identity?

The `projectName` should not change because of these changes. This change actually more aligns the root package name to what is already done for project names: https://github.com/snyk/snyk-gradle-plugin/blob/a444194f1199afece07232f4568773f36f9bfb9f/lib/index.ts#L306-L316

## Snapshot churn?

This should change dependency graphs for CLI monitor projects, and only a part of Gradle customers, so after discussing with some stakeholders in Team Fix, have deemed it should not be dangerous to snapshot churn.
