### PR TITLE
Pipeline cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,24 +250,24 @@ workflows:
       - lint:
           name: Lint
           context: nodejs-install
-          <<: *filters_branches_ignore_main
           node_version: '20.9'
+          <<: *filters_branches_ignore_main
 
       - test-unix:
           name: Test OS=Unix Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_unix
-          <<: *filters_branches_ignore_main
           requires:
             - lint
+          <<: *filters_branches_ignore_main
 
       - test-windows:
           name: Test OS=Windows Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_win
-          <<: *filters_branches_ignore_main
           requires:
             - lint
+          <<: *filters_branches_ignore_main
 
       - release:
           name: Release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ workflows:
           context: nodejs-install
           <<: *test_matrix_unix
           requires:
-            - lint
+            - Lint
           <<: *filters_branches_ignore_main
 
       - test-windows:
@@ -266,7 +266,7 @@ workflows:
           context: nodejs-install
           <<: *test_matrix_win
           requires:
-            - lint
+            - Lint
           <<: *filters_branches_ignore_main
 
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  node: circleci/node@5.1.0
   win: circleci/windows@2.4.0
   prodsec: snyk/prodsec-orb@1.0
 
@@ -21,40 +22,38 @@ windows_defaults: &windows_defaults
   executor:
     name: win/default
     size: large
+    shell: bash
 
 test_matrix_unix: &test_matrix_unix
   matrix:
     parameters:
-      node_version: ['12', '16']
+#      node_version: ['16.18', '18.18', '20.9']
+      node_version: ['16.18']
       jdk_version: ['8.0.292.j9-adpt']
-      gradle_version: ['3.4.1', '4.10', '5.5', '6.2.1']
+#      gradle_version: ['4.10', '5.5', '6.2.1']
+      gradle_version: ['6.2.1']
+
 test_matrix_win: &test_matrix_win
   matrix:
     parameters:
-      node_version: ['12', '16']
+#      node_version: ['16', '18', '20']
+      node_version: ['16']
       jdk_version: ['8']
-      gradle_version: ['4.10', '5.5', '6.2.1']
+#      gradle_version: ['4.10', '5.5', '6.2.1']
+      gradle_version: ['6.2.1']
 
 commands:
-  install_deps:
-    description: Install dependencies
+  node-install-packages:
+    description: Install NPM packages
     steps:
       - run:
-          name: Install dependencies
-          command: npm install
-  install_node_npm:
-    description: Install correct Node version
-    parameters:
-      node_version:
-        type: string
-        default: ''
-    steps:
-      - run:
-          name: Install correct version of Node
-          command: nvm install << parameters.node_version >>
-      - run:
-          name: Use correct version of Node
-          command: nvm use << parameters.node_version >>
+          # The Node orb handles all the boring work for us, but they do not understand repos with no package-lock.json
+          name: Create fake package-lock.json
+          command: touch package-lock.json
+      - node/install-packages:
+          cache-only-lockfile: false
+          override-ci-command: npm i
+
   show_node_version:
     description: Log Node and npm version
     steps:
@@ -64,6 +63,7 @@ commands:
       - run:
           name: NPM version
           command: npm --version
+
   install_gradle_windows:
     description: Install gradle
     parameters:
@@ -71,29 +71,40 @@ commands:
         type: string
         default: ''
     steps:
-      - run: choco install gradle --version=<< parameters.gradle_version >>
+      - restore_cache:
+          name: Restoring Gradle binary from cache
+          keys:
+            - chocolatey-gradle-cache-{{ arch }}-v2
+      - run:
+          name: Installing Gradle
+          command: choco install gradle --version=<< parameters.gradle_version >>
+      - save_cache:
+          key: chocolatey-gradle-cache-{{ arch }}-v2
+          paths:
+            - ~\AppData\Local\Temp\chocolatey\gradle
+
   install_sdkman:
     description: Install SDKMAN
     steps:
       - restore_cache:
-          name: Restore SDKMan executable
+          name: Restore Sdkman executable and binaries from cache
           keys:
             - sdkman-cli-{{ arch }}-v1
       - run:
           name: Installing SDKMAN
           command: |
-            if ! command -v sdk &> /dev/null
+            if [ ! -d ~/.sdkman ]
             then
               curl -s "https://get.sdkman.io?rcupdate=false" | bash
             fi
-            
             echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
             source $BASH_ENV
-            sdk list java
+            sdk version
       - save_cache:
           key: sdkman-cli-{{ arch }}-v1
           paths:
             - ~/.sdkman
+
   install_gradle_unix:
     description: Install gradle
     parameters:
@@ -101,9 +112,18 @@ commands:
         type: string
         default: ''
     steps:
+      - restore_cache:
+          name: Restore Gradle binary from cache
+          keys:
+            - gradle-cli-{{ arch }}-v1
       - run:
           name: Installing Gradle
           command: sdk install gradle << parameters.gradle_version >>
+      - save_cache:
+          key: gradle-cli-{{ arch }}-v1
+          paths:
+            - ~/.sdkman/candidates/gradle/
+
   install_jdk_unix:
     description: Install JDK
     parameters:
@@ -111,9 +131,18 @@ commands:
         type: string
         default: ''
     steps:
+      - restore_cache:
+          name: Restore Java binary from cache
+          keys:
+            - java-cli-{{ arch }}-v1
       - run:
           name: Installing JDK
           command: sdk install java << parameters.jdk_version >>
+      - save_cache:
+          key: java-cli-{{ arch }}-v1
+          paths:
+            - ~/.sdkman/candidates/java/
+
   install_jdk_windows:
     description: Install JDK
     parameters:
@@ -121,22 +150,32 @@ commands:
         type: string
         default: ''
     steps:
+      - restore_cache:
+          name: Restoring Java binary from cache
+          keys:
+            - chocolatey-jdk-cache-{{ arch }}-v3
+          paths:
+            - ~\AppData\Local\Temp\chocolatey\Temurin*
       - run:
           name: Installing JDK
           command: choco install openjdk<< parameters.jdk_version >>
-
+      - save_cache:
+          key: chocolatey-jdk-cache-{{ arch }}-v3
+          paths:
+            - ~\AppData\Local\Temp\chocolatey
 jobs:
   lint:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
-      - install_deps
+      - node-install-packages
       - show_node_version
       - run:
           name: Run lint
           command: npm run lint
+
   test-windows:
     <<: *defaults
     <<: *windows_defaults
@@ -148,14 +187,14 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - checkout
-      - install_node_npm:
-          node_version: << parameters.node_version >>
       - install_jdk_windows:
           jdk_version: << parameters.jdk_version >>
       - install_gradle_windows:
           gradle_version: << parameters.gradle_version >>
-      - install_deps
+      - node/install:
+          node-version: << parameters.node_version >>
       - show_node_version
+      - node-install-packages
       - run:
           name: Run tests
           command: npm test
@@ -163,7 +202,7 @@ jobs:
   test-unix:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     environment:
       GRADLE_VERSION: << parameters.gradle_version >>
     steps:
@@ -173,19 +212,18 @@ jobs:
           jdk_version: << parameters.jdk_version >>
       - install_gradle_unix:
           gradle_version: << parameters.gradle_version >>
-      - install_deps
+      - node-install-packages
       - show_node_version
-      - run:
-          name: Run tests
-          command: npm test
+#      - run:
+#          name: Run tests
+#          command: npm test
 
   release:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
-      - install_deps
       - run: sudo npm i -g semantic-release@19 @semantic-release/exec pkg
       - run:
           name: Publish to GitHub
@@ -195,19 +233,22 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-      - prodsec/secrets-scan:
-          name: Scan repository for secrets
-          context:
-            - snyk-bot-slack
-          channel: os-team-managed-alerts
-      - lint:
-          name: Lint
-          context: nodejs-install
-          node_version: '12'
+#      - prodsec/secrets-scan:
+#          name: Scan repository for secrets
+#          context:
+#            - snyk-bot-slack
+#          channel: os-team-managed-alerts
+
+#      - lint:
+#          name: Lint
+#          context: nodejs-install
+#          node_version: '20'
+
       - test-unix:
           name: Test OS=Unix Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_unix
+
       - test-windows:
           name: Test OS=Windows Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
@@ -216,7 +257,7 @@ workflows:
       - release:
           name: Release
           context: nodejs-app-release
-          node_version: '14.17.6'
+          node_version: '20'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,28 @@ windows_defaults: &windows_defaults
 test_matrix_unix: &test_matrix_unix
   matrix:
     parameters:
-      node_version: ['16.18', '18.18', '20.9']
-      jdk_version: ['8.0.292.j9-adpt']
-      gradle_version: ['4.10', '5.5', '6.2.1']
+      node_version: [ '16.18', '18.18', '20.9' ]
+      jdk_version: [ '8.0.292.j9-adpt' ]
+      gradle_version: [ '4.10', '5.5', '6.2.1' ]
 
 test_matrix_win: &test_matrix_win
   matrix:
     parameters:
-      node_version: ['16', '18', '20']
-      jdk_version: ['8']
-      gradle_version: ['4.10', '5.5', '6.2.1']
+      node_version: [ '16', '18', '20' ]
+      jdk_version: [ '8' ]
+      gradle_version: [ '4.10', '5.5', '6.2.1' ]
+
+filters_branches_only_main: &filters_branches_only_main
+  filters:
+    branches:
+      only:
+        - main
+
+filters_branches_ignore_main: &filters_branches_ignore_main
+  filters:
+    branches:
+      ignore:
+        - main
 
 commands:
   node-install-packages:
@@ -233,27 +245,32 @@ workflows:
           context:
             - snyk-bot-slack
           channel: os-team-managed-alerts
+          <<: *filters_branches_ignore_main
 
       - lint:
           name: Lint
           context: nodejs-install
+          <<: *filters_branches_ignore_main
           node_version: '20.9'
 
       - test-unix:
           name: Test OS=Unix Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_unix
+          <<: *filters_branches_ignore_main
+          requires:
+            - lint
 
       - test-windows:
           name: Test OS=Windows Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
           context: nodejs-install
           <<: *test_matrix_win
+          <<: *filters_branches_ignore_main
+          requires:
+            - lint
 
       - release:
           name: Release
           context: nodejs-app-release
           node_version: '20.9'
-          filters:
-            branches:
-              only:
-                - master
+          <<: *filters_branches_only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,16 @@ windows_defaults: &windows_defaults
 test_matrix_unix: &test_matrix_unix
   matrix:
     parameters:
-#      node_version: ['16.18', '18.18', '20.9']
-      node_version: ['16.18']
+      node_version: ['16.18', '18.18', '20.9']
       jdk_version: ['8.0.292.j9-adpt']
-#      gradle_version: ['4.10', '5.5', '6.2.1']
-      gradle_version: ['6.2.1']
+      gradle_version: ['4.10', '5.5', '6.2.1']
 
 test_matrix_win: &test_matrix_win
   matrix:
     parameters:
-#      node_version: ['16', '18', '20']
-      node_version: ['16']
+      node_version: ['16', '18', '20']
       jdk_version: ['8']
-#      gradle_version: ['4.10', '5.5', '6.2.1']
-      gradle_version: ['6.2.1']
+      gradle_version: ['4.10', '5.5', '6.2.1']
 
 commands:
   node-install-packages:
@@ -74,14 +70,14 @@ commands:
       - restore_cache:
           name: Restoring Gradle binary from cache
           keys:
-            - chocolatey-gradle-cache-{{ arch }}-v2
+            - chocolatey-gradle-cache-{{ arch }}-v3
       - run:
           name: Installing Gradle
-          command: choco install gradle --version=<< parameters.gradle_version >>
+          command: choco install gradle --version=<< parameters.gradle_version >> --cache ~\AppData\Local\Temp\gradle
       - save_cache:
-          key: chocolatey-gradle-cache-{{ arch }}-v2
+          key: chocolatey-gradle-cache-{{ arch }}-v3
           paths:
-            - ~\AppData\Local\Temp\chocolatey\gradle
+            - ~\AppData\Local\Temp\gradle
 
   install_sdkman:
     description: Install SDKMAN
@@ -89,19 +85,20 @@ commands:
       - restore_cache:
           name: Restore Sdkman executable and binaries from cache
           keys:
-            - sdkman-cli-{{ arch }}-v1
+            - sdkman-cli-{{ arch }}-v2
       - run:
           name: Installing SDKMAN
           command: |
             if [ ! -d ~/.sdkman ]
             then
               curl -s "https://get.sdkman.io?rcupdate=false" | bash
+              sed -i -e 's/sdkman_auto_answer=false/sdkman_auto_answer=true/g' ~/.sdkman/etc/config
             fi
             echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
             source $BASH_ENV
             sdk version
       - save_cache:
-          key: sdkman-cli-{{ arch }}-v1
+          key: sdkman-cli-{{ arch }}-v2
           paths:
             - ~/.sdkman
 
@@ -153,16 +150,14 @@ commands:
       - restore_cache:
           name: Restoring Java binary from cache
           keys:
-            - chocolatey-jdk-cache-{{ arch }}-v3
-          paths:
-            - ~\AppData\Local\Temp\chocolatey\Temurin*
+            - chocolatey-jdk-cache-{{ arch }}-v4
       - run:
           name: Installing JDK
-          command: choco install openjdk<< parameters.jdk_version >>
+          command: choco install openjdk<< parameters.jdk_version >> --cache ~\AppData\Local\Temp\jdk
       - save_cache:
-          key: chocolatey-jdk-cache-{{ arch }}-v3
+          key: chocolatey-jdk-cache-{{ arch }}-v4
           paths:
-            - ~\AppData\Local\Temp\chocolatey
+            - ~\AppData\Local\Temp\jdk
 jobs:
   lint:
     <<: *defaults
@@ -214,9 +209,9 @@ jobs:
           gradle_version: << parameters.gradle_version >>
       - node-install-packages
       - show_node_version
-#      - run:
-#          name: Run tests
-#          command: npm test
+      - run:
+          name: Run tests
+          command: npm test
 
   release:
     <<: *defaults
@@ -233,16 +228,16 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-#      - prodsec/secrets-scan:
-#          name: Scan repository for secrets
-#          context:
-#            - snyk-bot-slack
-#          channel: os-team-managed-alerts
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: os-team-managed-alerts
 
-#      - lint:
-#          name: Lint
-#          context: nodejs-install
-#          node_version: '20'
+      - lint:
+          name: Lint
+          context: nodejs-install
+          node_version: '20.9'
 
       - test-unix:
           name: Test OS=Unix Node=<<matrix.node_version>> JDK=<<matrix.jdk_version>> Gradle=<<matrix.gradle_version>>
@@ -257,7 +252,7 @@ workflows:
       - release:
           name: Release
           context: nodejs-app-release
-          node_version: '20'
+          node_version: '20.9'
           filters:
             branches:
               only:

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -1,0 +1,13 @@
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-pr-message: "Your PR has not had any activity for 60 days. In 7 days I'll close it. Make some activity to remove this."
+          close-pr-message: "Your PR has now been stale for 7 days. I'm closing it."

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,5 @@
+{
+  "branches": [
+    "main"
+  ]
+}


### PR DESCRIPTION
Each of the the pipeline executors spent like 4-6 minutes downloading the same things on each run.

* Added the usual `pr-housekeeping` Github workflow for stale branches and PRs
* Added cache steps for all downloads
* Removed old and obsolete Node version steps and added new LTS
* Replaced homemade Node installations with the CircleCI orb
* Default branch to `main`
* Added missing `requires`