### PR TITLE
Use complete project path when filtering subprojects

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -334,7 +334,7 @@ allprojects { Project currProj ->
             def shouldScanProject = {
                 onlyProj == null ||
                 (onlyProj == '.' && it.name == defaultProjectName) ||
-                it.name == onlyProj
+                formatPath(it.path) == onlyProj
             }
             def projectsDict = [:]
 


### PR DESCRIPTION
- [ ] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does

This resolves #195, allowing the tool to properly recognize `--sub-project` arguments that refer to nested subprojects, e.g. `foo/bar` for the Gradle project path `:foo:bar`. Currently, this does not work.

### Notes for the reviewer

I'm not sure how to write the test for this, since I haven't dug into the repo too much. Please let me know if you have a recommendation for anything else that needs to be done.

#### How should this be manually tested?

Ran with `--sub-project` for a nested Gradle subproject, e.g. `foo/bar`, and found it to be recognized.