### PR TITLE
Fix: subprojects filtering

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -334,7 +334,8 @@ allprojects { Project currProj ->
             def shouldScanProject = {
                 onlyProj == null ||
                 (onlyProj == '.' && it.name == defaultProjectName) ||
-                it.name == onlyProj
+                it.name == onlyProj ||
+                formatPath(it.path) == onlyProj
             }
             def projectsDict = [:]
 
@@ -433,7 +434,8 @@ allprojects { Project currProj ->
             def shouldScanProject = {
                 onlyProj == null ||
                 (onlyProj == '.' && it.name == defaultProjectName) ||
-                it.name == onlyProj
+                it.name == onlyProj ||
+                formatPath(it.path) == onlyProj
             }
             def projectsDict = [:]
 

--- a/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
+++ b/test/fixtures-with-wrappers/with-lock-file/dep-graph.json
@@ -19,10 +19,10 @@
       }
     },
     {
-      "id": "com.google.guava:guava@32.1.3-jre",
+      "id": "com.google.guava:guava@33.0.0-jre",
       "info": {
         "name": "com.google.guava:guava",
-        "version": "32.1.3-jre"
+        "version": "33.0.0-jre"
       }
     },
     {
@@ -33,10 +33,10 @@
       }
     },
     {
-      "id": "com.google.guava:failureaccess@1.0.1",
+      "id": "com.google.guava:failureaccess@1.0.2",
       "info": {
         "name": "com.google.guava:failureaccess",
-        "version": "1.0.1"
+        "version": "1.0.2"
       }
     },
     {
@@ -54,17 +54,17 @@
       }
     },
     {
-      "id": "org.checkerframework:checker-qual@3.37.0",
+      "id": "org.checkerframework:checker-qual@3.41.0",
       "info": {
         "name": "org.checkerframework:checker-qual",
-        "version": "3.37.0"
+        "version": "3.41.0"
       }
     },
     {
-      "id": "com.google.errorprone:error_prone_annotations@2.21.1",
+      "id": "com.google.errorprone:error_prone_annotations@2.23.0",
       "info": {
         "name": "com.google.errorprone:error_prone_annotations",
-        "version": "2.21.1"
+        "version": "2.23.0"
       }
     },
     {
@@ -72,6 +72,13 @@
       "info": {
         "name": "com.google.errorprone:error_prone_annotations",
         "version": "2.11.0"
+      }
+    },
+    {
+      "id": "com.google.guava:failureaccess@1.0.1",
+      "info": {
+        "name": "com.google.guava:failureaccess",
+        "version": "1.0.1"
       }
     },
     {
@@ -100,7 +107,7 @@
             "nodeId": "org.codehaus.groovy:groovy@3.0.3"
           },
           {
-            "nodeId": "com.google.guava:guava@32.1.3-jre"
+            "nodeId": "com.google.guava:guava@33.0.0-jre"
           },
           {
             "nodeId": "com.google.guava:guava@31.1-jre"
@@ -113,11 +120,11 @@
         "deps": []
       },
       {
-        "nodeId": "com.google.guava:guava@32.1.3-jre",
-        "pkgId": "com.google.guava:guava@32.1.3-jre",
+        "nodeId": "com.google.guava:guava@33.0.0-jre",
+        "pkgId": "com.google.guava:guava@33.0.0-jre",
         "deps": [
           {
-            "nodeId": "com.google.guava:failureaccess@1.0.1"
+            "nodeId": "com.google.guava:failureaccess@1.0.2"
           },
           {
             "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava"
@@ -126,10 +133,10 @@
             "nodeId": "com.google.code.findbugs:jsr305@3.0.2"
           },
           {
-            "nodeId": "org.checkerframework:checker-qual@3.37.0"
+            "nodeId": "org.checkerframework:checker-qual@3.41.0"
           },
           {
-            "nodeId": "com.google.errorprone:error_prone_annotations@2.21.1"
+            "nodeId": "com.google.errorprone:error_prone_annotations@2.23.0"
           }
         ]
       },
@@ -137,9 +144,6 @@
         "nodeId": "com.google.guava:guava@31.1-jre",
         "pkgId": "com.google.guava:guava@31.1-jre",
         "deps": [
-          {
-            "nodeId": "com.google.guava:failureaccess@1.0.1:pruned"
-          },
           {
             "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned"
           },
@@ -150,6 +154,9 @@
             "nodeId": "com.google.errorprone:error_prone_annotations@2.11.0"
           },
           {
+            "nodeId": "com.google.guava:failureaccess@1.0.1"
+          },
+          {
             "nodeId": "org.checkerframework:checker-qual@3.12.0"
           },
           {
@@ -158,8 +165,8 @@
         ]
       },
       {
-        "nodeId": "com.google.guava:failureaccess@1.0.1",
-        "pkgId": "com.google.guava:failureaccess@1.0.1",
+        "nodeId": "com.google.guava:failureaccess@1.0.2",
+        "pkgId": "com.google.guava:failureaccess@1.0.2",
         "deps": []
       },
       {
@@ -173,24 +180,14 @@
         "deps": []
       },
       {
-        "nodeId": "org.checkerframework:checker-qual@3.37.0",
-        "pkgId": "org.checkerframework:checker-qual@3.37.0",
+        "nodeId": "org.checkerframework:checker-qual@3.41.0",
+        "pkgId": "org.checkerframework:checker-qual@3.41.0",
         "deps": []
       },
       {
-        "nodeId": "com.google.errorprone:error_prone_annotations@2.21.1",
-        "pkgId": "com.google.errorprone:error_prone_annotations@2.21.1",
+        "nodeId": "com.google.errorprone:error_prone_annotations@2.23.0",
+        "pkgId": "com.google.errorprone:error_prone_annotations@2.23.0",
         "deps": []
-      },
-      {
-        "nodeId": "com.google.guava:failureaccess@1.0.1:pruned",
-        "pkgId": "com.google.guava:failureaccess@1.0.1",
-        "deps": [],
-        "info": {
-          "labels": {
-            "pruned": "true"
-          }
-        }
       },
       {
         "nodeId": "com.google.guava:listenablefuture@9999.0-empty-to-avoid-conflict-with-guava:pruned",
@@ -215,6 +212,11 @@
       {
         "nodeId": "com.google.errorprone:error_prone_annotations@2.11.0",
         "pkgId": "com.google.errorprone:error_prone_annotations@2.11.0",
+        "deps": []
+      },
+      {
+        "nodeId": "com.google.guava:failureaccess@1.0.1",
+        "pkgId": "com.google.guava:failureaccess@1.0.1",
         "deps": []
       },
       {

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -565,6 +565,26 @@ test('multi-project: correct deps for subproject with the same name, one depende
   expect(nodeIds.indexOf('joda-time:joda-time@2.2')).toBe(-1);
 });
 
+test('multi-project: right subproject to scan, using --sub-project', async () => {
+  const result = await inspect(
+    '.',
+    path.join(fixtureDir('subprojects-same-name'), 'build.gradle'),
+    { subProject: 'greeter/subproj' },
+  );
+
+  expect(result.dependencyGraph.rootPkg.name).toBe(
+    'subprojects-same-name/greeter/subproj',
+  );
+  expect(result.meta!.gradleProjectName).toBe(
+    'subprojects-same-name/greeter/subproj',
+  );
+  expect(result.plugin.meta!.allSubProjectNames).toEqual([
+    'greeter',
+    'subproj',
+    'greeter/subproj',
+  ]);
+});
+
 test('multi-project: correct deps for subproject with the same name, one dependent on another, using --sub-project', async () => {
   const result = await inspect(
     '.',


### PR DESCRIPTION
This comes in completion of [this PR raise by the client](https://github.com/snyk/snyk-gradle-plugin/pull/268), adding tests

- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

What this does
This resolves https://github.com/snyk/snyk-gradle-plugin/issues/195, allowing the tool to properly recognize --sub-project arguments that refer to nested subprojects, e.g. foo/bar for the Gradle project path :foo:bar.