### PR TITLE
fix: Safely handle module artifact retrieval failures

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -701,8 +701,11 @@ function buildArgs(
 
   // Gradle 7 introduced configuration caching which we don't support yet
   // If it is enabled in a gradle.properties file, it can be disabled on the command line with --no-configuration-cache
-  if (gradleVersion.match(/Gradle 7/) || gradleVersion.match(/Gradle 8/))
+  // It is enabled by default in Gradle 9.
+  // The regex matches Gradle 7, 8, 9 and any future two-digit versions (10, 11, etc.).
+  if (gradleVersion.match(/Gradle ([7-9]|\d{2,})/)) {
     args.push('--no-configuration-cache');
+  }
 
   // There might be a legacy --configuration option in 'args'.
   // It has been superseded by --configuration-matching option for Snyk CLI (see buildArgs),

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -348,20 +348,20 @@ allprojects { Project currProj ->
                     }
             }
             // name of target project - either specified by --file or the root of a multi-module build
-            String defaultProjectName = task.project.name
+            String defaultProjectName = currProj.name
             // the path of the above, preferred over name because path is unique
-            String defaultProjectKey = isRootPath(task.project.path) ? defaultProjectName : formatPath(task.project.path)
+            String defaultProjectKey = isRootPath(currProj.path) ? defaultProjectName : formatPath(currProj.path)
             // collect all subprojects names that are not target
             List allSubProjectNames = []
             allprojects
-                .findAll({ it.path != task.project.path })
+                .findAll({ it.path != currProj.path })
                 .each({
                     String projKey = formatPath(it.path)
                     allSubProjectNames.add(projKey)
                 })
             def shouldScanProject = {
                 onlyProj == null ||
-                (onlyProj == '.' && it.name == defaultProjectName) ||
+                (onlyProj == '.' && it.path == currProj.path) ||
                 it.name == onlyProj ||
                 formatPath(it.path) == onlyProj
             }
@@ -450,18 +450,18 @@ allprojects { Project currProj ->
                     }
             }
 
-            String defaultProjectName = task.project.name
-            String defaultProjectKey = isRootPath(task.project.path) ? defaultProjectName : formatPath(task.project.path)
+            String defaultProjectName = currProj.name
+            String defaultProjectKey = isRootPath(currProj.path) ? defaultProjectName : formatPath(currProj.path)
             List allSubProjectNames = []
             allprojects
-                .findAll({ it.path != task.project.path })
+                .findAll({ it.path != currProj.path })
                 .each({
                     String projKey = formatPath(it.path)
                     allSubProjectNames.add(projKey)
                 })
             def shouldScanProject = {
                 onlyProj == null ||
-                (onlyProj == '.' && it.name == defaultProjectName) ||
+                (onlyProj == '.' && it.path == currProj.path) ||
                 it.name == onlyProj ||
                 formatPath(it.path) == onlyProj
             }

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -124,7 +124,13 @@ def hashString(String str) {
 def loadGraph(Iterable deps, GradleGraph graph, parentId, currentChain) {
     deps.each { dep ->
         dep.each { d ->
-            def moduleArtifacts = d.getModuleArtifacts()
+            def moduleArtifacts
+            try {
+                moduleArtifacts = d.getModuleArtifacts()
+            } catch (Exception ex) {
+                debugLog("failed to get artifacts for dep: `$d`")
+                return
+            }
             moduleArtifacts.each { a ->
                 def childName = "${d.moduleGroup}:${d.moduleName}"
                 def childId = "${childName}:${a.type}"
@@ -147,7 +153,13 @@ def loadGraph(Iterable deps, GradleGraph graph, parentId, currentChain) {
 def loadSha1MapGraph(Iterable deps, GradleGraph graph, parentId, currentChain, sha1Map) {
     deps.each { dep ->
         dep.each { d ->
-            def moduleArtifacts = d.getModuleArtifacts()
+            def moduleArtifacts
+            try {
+                moduleArtifacts = d.getModuleArtifacts()
+            } catch (Exception ex) {
+                debugLog("failed to get artifacts for dep: `$d`")
+                return
+            }
             moduleArtifacts.each { a ->
                 def childName = "${d.moduleGroup}:${d.moduleName}"
                 def childId = "${childName}:${a.type}"

--- a/test/fixtures/modern-android/app/build.gradle
+++ b/test/fixtures/modern-android/app/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id('com.android.application') version '8.3.0'
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    compileSdk = 30
+    defaultConfig {
+        applicationId = 'org.gradle.samples'
+        namespace = 'org.gradle.samples'
+        minSdk = 16
+        targetSdk = 30
+        versionCode = 1
+        versionName = '1.0'
+        testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
+    }
+    buildTypes {
+        release {
+            minifyEnabled = false
+            proguardFiles(getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro')
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}

--- a/test/fixtures/modern-android/build.gradle
+++ b/test/fixtures/modern-android/build.gradle
@@ -1,0 +1,4 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/test/fixtures/modern-android/settings.gradle
+++ b/test/fixtures/modern-android/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = 'my-app'
+
+include ':app'

--- a/test/functional/gradle-plugin.spec.ts
+++ b/test/functional/gradle-plugin.spec.ts
@@ -159,8 +159,8 @@ describe('Gradle Plugin', () => {
     );
   });
 
-  it.each([7, 8])(
-    'make sure configuration cache is switched off for Gradle %s',
+  it.each([7, 8, 9, 10])(
+    'make sure configuration cache is switched off for Gradle %s and higher',
     async (version) => {
       const result = testableMethods.buildArgs(
         '.',

--- a/test/system/android.test.ts
+++ b/test/system/android.test.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import { fixtureDir } from '../common';
+import { inspect } from '../../lib';
+
+const gradleVersionFromProcess = process.env.GRADLE_VERSION || '';
+const gradleVersionInUse: number = parseInt(
+  gradleVersionFromProcess.split('.')[0],
+);
+const isAndroidSupported: boolean = gradleVersionInUse > 7 ? true : false;
+if (isAndroidSupported) {
+  describe('android version 8 build', () => {
+    test('we can inspect naively', async () => {
+      const data = await inspect(
+        '.',
+        path.join(fixtureDir('modern-android'), 'build.gradle'),
+        { allSubProjects: true },
+      );
+      expect(data.scannedProjects.length).toEqual(2);
+    }, 90000);
+
+    test('we can inspect with configuration attribute selector', async () => {
+      const data = await inspect(
+        '.',
+        path.join(fixtureDir('modern-android'), 'build.gradle'),
+        {
+          allSubProjects: true,
+          'configuration-attributes':
+            'buildtype:release,usage:java-runtime,myflavor:local',
+        },
+      );
+      expect(data.scannedProjects.length).toEqual(2);
+    }, 90000);
+  });
+} else {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  test('minimum gradle version for modern android project is 8', () => {});
+}

--- a/test/system/kotlin.test.ts
+++ b/test/system/kotlin.test.ts
@@ -21,7 +21,7 @@ if (isKotlinSupported) {
       path.join(fixtureDir('gradle-kts'), 'build.gradle.kts'),
     );
     expect(result.dependencyGraph?.rootPkg.name).toMatch('gradle-kts');
-    expect(result.meta!.gradleProjectName).toMatch('gradle-kts');
+    expect(result.meta?.gradleProjectName).toMatch('gradle-kts');
     const pkgs = result.dependencyGraph?.getDepPkgs() || [];
     const nodeIds: string[] = [];
     Object.keys(pkgs).forEach((id) => {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written
- [ ] Commit history is tidy

### What this does

Relatively inelegantly handles https://github.com/snyk/snyk-gradle-plugin/issues/306.

More specifically, the main issue encountered in `v5.0.0` for Android projects was failures to correctly resolve certain module artifacts as some configurations presented criteria that no module could meet. A simple `try/catch` here results in `v5.0.0` producing effectively identical dep-graphs as were produced by `v4.9.2` -- however, the solution seems a little inelegant to me, and I would prefer one that could check ahead of time whether some configuration would fail on the call to `getModuleArtifacts()`.

This _does not_:
* Uncover why moving to resolved artifacts over resolved dependencies was problematic for android
* Address the probably faulty "one artifact per dependency" assumption

Also included are some tweaks to the script to stop using deprecated methods and accessors (specifically `task.project`). Task actions will no longer have direct access to the `Project` object in Gradle 9, however, we already have the project from the `allProjects { currProject -> ... }` block.

#### How should this be manually tested?

Check out the [nowinandroid project](https://github.com/android/nowinandroid) and navigate to the `test/fixtures/modern-android` directory

Then run the following:
```
gradle snykResolvedDepsJson --init-script path/to/init.gradle --no-configuration-cache -Dorg.gradle.parallel=
```
And:
```
gradle snykNormalizedResolvedDepsJson --init-script path/to/init.gradle --no-configuration-cache --stacktrace -Dorg.gradle.parallel=
```

It is strongly suggested that you try this with gradle versions 8, and 9.0.0-rc-1 (`nowinandroid` supports a minimum of gradle 8).
