### PR TITLE
fix: Pre-compute child links and use set for ancestry

### DIFF
--- a/test/functional/graph.spec.ts
+++ b/test/functional/graph.spec.ts
@@ -1,5 +1,5 @@
 import { DepGraphBuilder } from '@snyk/dep-graph';
-import { buildGraph, findChildren } from '../../lib/graph';
+import { buildGraph } from '../../lib/graph';
 
 describe('buildGraph', () => {
   it('returns empty when graph empty', async () => {
@@ -293,72 +293,5 @@ describe('buildGraph', () => {
     expect(expectNoLabel).toContainEqual({
       info: {},
     });
-  });
-});
-
-describe('findChildren', () => {
-  it('returns empty when graph empty', () => {
-    const received = findChildren('root-node', [], {});
-    expect(received).toEqual([]);
-  });
-
-  it('returns empty when graph has no parent id', () => {
-    const received = findChildren('not-found', [], {
-      'a@1': {
-        name: 'a',
-        version: '1',
-        parentIds: ['root-node'],
-      },
-    });
-    expect(received).toEqual([]);
-  });
-
-  it('returns nodes with given parent id', () => {
-    const received = findChildren('root-node', [], {
-      'a@1': {
-        name: 'a',
-        version: '1',
-        parentIds: ['root-node'],
-      },
-      'b@1': {
-        name: 'b',
-        version: '1',
-        parentIds: ['a@1'],
-      },
-      'c@1': {
-        name: 'c',
-        version: '1',
-        parentIds: ['root-node'],
-      },
-    });
-    expect(received).toEqual([
-      { id: 'a@1', ancestry: [], parentId: 'root-node' },
-      { id: 'c@1', ancestry: [], parentId: 'root-node' },
-    ]);
-  });
-
-  it('returns nodes with given parent id when multiple parents', () => {
-    const received = findChildren('root-node', [], {
-      'a@1': {
-        name: 'a',
-        version: '1',
-        parentIds: ['root-node'],
-      },
-      'b@1': {
-        name: 'b',
-        version: '1',
-        parentIds: ['root-node', 'a@1'],
-      },
-      'c@1': {
-        name: 'c',
-        version: '1',
-        parentIds: ['root-node'],
-      },
-    });
-    expect(received).toEqual([
-      { id: 'a@1', ancestry: [], parentId: 'root-node' },
-      { id: 'b@1', ancestry: [], parentId: 'root-node' },
-      { id: 'c@1', ancestry: [], parentId: 'root-node' },
-    ]);
   });
 });


### PR DESCRIPTION
- [ ] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy

### What this does

This provides further performance improvements to the dep-graph generation of the `snyk-gradle-plugin`.

Specifically:
1. `findChildren` was recalculating the children for each node afresh. This added additional complexity of `O(N * max_P)` to each loop.
2. Ancestry was using `Array.includes` which is `O(N)`. We still need to pay the cost when generating the next set of ancestors -- however, checking if we're in a cyclic section is now `O(1)`.

This takes us from:
```
  snyk-gradle-plugin The command produced JSONDEPS output of 117528 characters +34ms
  snyk-gradle-plugin The following attributes and their possible values were found in your configurations:            org.gradle.category: library, verification
  snyk-gradle-plugin               org.gradle.usage: java-runtime, java-api
  snyk-gradle-plugin     org.gradle.libraryelements: classes, jar
  snyk-gradle-plugin org.gradle.dependency.bundling: external
  snyk-gradle-plugin     org.gradle.jvm.environment: standard-jvm
  snyk-gradle-plugin         org.gradle.jvm.version: 17
  snyk-gradle-plugin    org.gradle.verificationtype: test-results, main-sources
  snyk-gradle-plugin      org.gradle.testsuite.name: test +1ms
  snyk-test Found 1 projects from 1 detected manifests +48s
```

To:
```
  snyk-gradle-plugin The command produced JSONDEPS output of 117528 characters +28ms
  snyk-gradle-plugin The following attributes and their possible values were found in your configurations:            org.gradle.category: library, verification
  snyk-gradle-plugin               org.gradle.usage: java-runtime, java-api
  snyk-gradle-plugin     org.gradle.libraryelements: classes, jar
  snyk-gradle-plugin org.gradle.dependency.bundling: external
  snyk-gradle-plugin     org.gradle.jvm.environment: standard-jvm
  snyk-gradle-plugin         org.gradle.jvm.version: 17
  snyk-gradle-plugin    org.gradle.verificationtype: test-results, main-sources
  snyk-gradle-plugin      org.gradle.testsuite.name: test +1ms
  snyk-test Found 1 projects from 1 detected manifests +11s
```

#### How should this be manually tested?

Inconveniently -- I've changed the `snyk-gradle-plugin` entry in the `package.json` for the CLI to point to my local repo and then building the CLI locally using `npm install && npm run build-cli:prod`.

I've then been testing on a project locally using this command and tracking the timing information
```
path/to/cli/bin/snyk test --all-projects --print-graph -d
```
