### PR TITLE
feat: add support for Gradle 9.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ test_matrix_unix_new_versions: &test_matrix_unix_new_versions
     parameters:
       node_version: [ '16.18', '18.18', '20.9' ]
       jdk_version: [ '17.0.9-jbr' ]
-      gradle_version: [ '7.3', '8.4' ]
+      gradle_version: [ '7.3', '8.4', '9.0.0' ]
 
 test_matrix_win: &test_matrix_win
   matrix:
@@ -55,7 +55,7 @@ test_matrix_win_new_versions: &test_matrix_win_new_versions
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '17.0.2' ]
       jdk_path: [ 'C:\Program Files\OpenJDK\jdk-17.0.2' ]
-      gradle_version: [ '7.3', '8.4' ]
+      gradle_version: [ '7.3', '8.4', '9.0.0' ]
 
 filters_branches_only_main: &filters_branches_only_main
   filters:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -656,9 +656,10 @@ function buildArgs(
     if (!fs.existsSync(resolvedTargetFilePath)) {
       throw new Error('File not found: "' + resolvedTargetFilePath + '"');
     }
-    args.push('--build-file');
 
-    args.push(resolvedTargetFilePath);
+    const resolvedTargetDir = path.dirname(resolvedTargetFilePath);
+    args.push('--project-dir');
+    args.push(resolvedTargetDir);
   }
 
   // Arguments to init script are supplied as properties: https://stackoverflow.com/a/48370451

--- a/test/fixtures-with-wrappers/empty-build-gradle-in-root/subproj/build.gradle
+++ b/test/fixtures-with-wrappers/empty-build-gradle-in-root/subproj/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures-with-wrappers/repo-content-filtering/build.gradle
+++ b/test/fixtures-with-wrappers/repo-content-filtering/build.gradle
@@ -12,7 +12,7 @@ repositories {
             excludeGroupByRegex "org.checkerframework.*"
         }
     }
-    jcenter()
+    gradlePluginPortal()
 }
 
 dependencies {

--- a/test/fixtures/android-cannot-auto-resolve/build.gradle
+++ b/test/fixtures/android-cannot-auto-resolve/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
 }

--- a/test/fixtures/custom-resolution-strategy-via-all/build.gradle
+++ b/test/fixtures/custom-resolution-strategy-via-all/build.gradle
@@ -3,8 +3,10 @@ apply plugin: 'java'
 group = 'com.github.jitpack'
 version = '1.0.0'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()

--- a/test/fixtures/custom-resolution-strategy-via-asterisk/build.gradle
+++ b/test/fixtures/custom-resolution-strategy-via-asterisk/build.gradle
@@ -3,8 +3,10 @@ apply plugin: 'java'
 group = 'com.github.jitpack'
 version = '1.0.0'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()

--- a/test/fixtures/gradle-kts-gradle9/build.gradle.kts
+++ b/test/fixtures/gradle-kts-gradle9/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
+    kotlin("plugin.jpa") version "2.2.0"
+}
+
+version = "1.0.0-SNAPSHOT"
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    testImplementation("org.jetbrains.kotlin:kotlin-reflect") {
+        exclude(module = "junit")
+    }
+}

--- a/test/fixtures/java-reachability-playground/build.gradle
+++ b/test/fixtures/java-reachability-playground/build.gradle
@@ -31,7 +31,10 @@ dependencies {
 
 group = 'org.example'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '1.8'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 publishing {
     publications {

--- a/test/fixtures/malformed-build-gradle/build.gradle
+++ b/test/fixtures/malformed-build-gradle/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-config-attributes-subproject/build.gradle
+++ b/test/fixtures/multi-config-attributes-subproject/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-config-attributes-subproject/subproj/build.gradle
+++ b/test/fixtures/multi-config-attributes-subproject/subproj/build.gradle
@@ -3,8 +3,10 @@ apply plugin: 'maven'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-config-attributes/build.gradle
+++ b/test/fixtures/multi-config-attributes/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-config/build.gradle
+++ b/test/fixtures/multi-config/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project gradle wrapper/subproj/build.gradle
+++ b/test/fixtures/multi-project gradle wrapper/subproj/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project-dependency-cycle/build.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
+++ b/test/fixtures/multi-project-dependency-cycle/subproj/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project-different-names/greeter/build.gradle
+++ b/test/fixtures/multi-project-different-names/greeter/build.gradle
@@ -1,9 +1,15 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'application'
     id 'distribution'
 }
 
-mainClassName = 'gradle.app.GreetPerson'
+if (GradleVersion.current() >= GradleVersion.version('7.0')) {
+    application.mainClass.set('gradle.app.GreetPerson')
+} else {
+    mainClassName = 'gradle.app.GreetPerson'
+}
 
 repositories {
     mavenCentral()

--- a/test/fixtures/multi-project-parallel/build.gradle
+++ b/test/fixtures/multi-project-parallel/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-parallel/subproj0/build.gradle
+++ b/test/fixtures/multi-project-parallel/subproj0/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-parallel/subproj1/build.gradle
+++ b/test/fixtures/multi-project-parallel/subproj1/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-parallel/subproj2/build.gradle
+++ b/test/fixtures/multi-project-parallel/subproj2/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-parallel/subproj3/build.gradle
+++ b/test/fixtures/multi-project-parallel/subproj3/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-parallel/subproj4/build.gradle
+++ b/test/fixtures/multi-project-parallel/subproj4/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/test/fixtures/multi-project-same-name/greeter/build.gradle
+++ b/test/fixtures/multi-project-same-name/greeter/build.gradle
@@ -1,9 +1,15 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'application'
     id 'distribution'
 }
 
-mainClassName = 'gradle.app.GreetPerson'
+if (GradleVersion.current() >= GradleVersion.version('7.0')) {
+    application.mainClass.set('gradle.app.GreetPerson')
+} else {
+    mainClassName = 'gradle.app.GreetPerson'
+}
 
 repositories {
     mavenCentral()

--- a/test/fixtures/multi-project-some-unscannable/subproj-fail/build.gradle
+++ b/test/fixtures/multi-project-some-unscannable/subproj-fail/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
+++ b/test/fixtures/multi-project-some-unscannable/subproj/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/multi-project/subproj/build.gradle
+++ b/test/fixtures/multi-project/subproj/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/no wrapper bat/build.gradle
+++ b/test/fixtures/no wrapper bat/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/no wrapper/build.gradle
+++ b/test/fixtures/no wrapper/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'java'
 
 group = 'com.github.jitpack'
 
-sourceCompatibility = 1.8 // java 8
-targetCompatibility = 1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenCentral()

--- a/test/fixtures/with-init-script/build.gradle
+++ b/test/fixtures/with-init-script/build.gradle
@@ -21,7 +21,10 @@ dependencies {
 
 group = 'org.example'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '1.8'
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 publishing {
     publications {

--- a/test/system/kotlin.test.ts
+++ b/test/system/kotlin.test.ts
@@ -3,19 +3,24 @@ import { fixtureDir } from '../common';
 import { inspect } from '../../lib';
 
 const gradleVersionFromProcess = process.env.GRADLE_VERSION || '';
-const gradleVersionInUse: number = parseInt(
-  gradleVersionFromProcess.split('.')[0],
-);
-const isKotlinSupported: boolean = gradleVersionInUse > 4 ? true : false;
-const kotlinVersion = gradleVersionInUse < 7 ? '1.3.21' : '1.8.10';
+const gradleVersionInUse: number =
+  parseInt(gradleVersionFromProcess.split('.')[0]) || 0;
+const kotlinVersion =
+  gradleVersionInUse < 7
+    ? '1.3.21'
+    : gradleVersionInUse < 9
+    ? '1.8.10'
+    : '2.2.0';
 const classifierMap: Record<number, string> = {
   7: ':gradle71',
   8: ':gradle76',
 };
 
-// Gradle .kts builds are slower than usual so timeout is set to 150 sec in package.json
-if (isKotlinSupported) {
-  test('build.gradle.kts files are supported with Gradle version > 5', async () => {
+if (gradleVersionInUse < 5) {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  test('build.gradle.kts are not supported with Gradle version < 5', () => {});
+} else if (gradleVersionInUse < 9) {
+  test('build.gradle.kts files are supported with Gradle version 5, 6, 7, 8', async () => {
     const result = await inspect(
       '.',
       path.join(fixtureDir('gradle-kts'), 'build.gradle.kts'),
@@ -59,6 +64,54 @@ if (isKotlinSupported) {
     });
   }, 200000);
 } else {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  test('build.gradle.kts are not supported with Gradle version < 5', () => {});
+  test('build.gradle.kts files are supported with Gradle version >= 9', async () => {
+    const result = await inspect(
+      '.',
+      path.join(fixtureDir('gradle-kts-gradle9'), 'build.gradle.kts'),
+    );
+    expect(result.dependencyGraph?.rootPkg.name).toMatch('gradle-kts-gradle9');
+    expect(result.meta?.gradleProjectName).toMatch('gradle-kts-gradle9');
+    const pkgs = result.dependencyGraph?.getDepPkgs() || [];
+    const nodeIds: string[] = [];
+    Object.keys(pkgs).forEach((id) => {
+      nodeIds.push(`${pkgs[id].name}@${pkgs[id].version}`);
+    });
+
+    const expectedNodeId = `org.jetbrains.kotlin:kotlin-stdlib@${kotlinVersion}`;
+    expect(nodeIds).toContain(expectedNodeId);
+
+    // double parsing to have access to internal depGraph data, no methods available to properly
+    // return the deps nodeIds list that belongs to a node
+    const graphObject: any = JSON.parse(JSON.stringify(result.dependencyGraph));
+    const { deps: directDependencies } = graphObject.graph.nodes[0];
+    const expectedDirectDependencies = [
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar@${kotlinVersion}`,
+      },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-build-tools-impl:jar@${kotlinVersion}`,
+      },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-compiler-embeddable:jar@${kotlinVersion}`,
+      },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar@${kotlinVersion}`,
+      },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable:jar@${kotlinVersion}`,
+      },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-noarg-compiler-plugin-embeddable:jar@${kotlinVersion}`,
+      },
+      { nodeId: `org.jetbrains.kotlin:abi-tools:jar@${kotlinVersion}` },
+      {
+        nodeId: `org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:jar@${kotlinVersion}`,
+      },
+      { nodeId: `org.jetbrains.kotlin:kotlin-reflect:jar@${kotlinVersion}` },
+    ];
+
+    expectedDirectDependencies.forEach((expectedDependency) => {
+      expect(directDependencies).toContainEqual(expectedDependency);
+    });
+  }, 200000);
 }


### PR DESCRIPTION
The summary of this PR:
* Add Gradle 9.0.0 to the CI matrix.
* Make the Gradle plugin use Gradle's `--project-dir` CLI option instead of `--build-file`.
* Refactor the Groovy tests to be compatible with all tested Gradle version.
* Add a separate Kotlin test for Gradle 9.0.0.

##  `--project-dir` instead of `--build-file`

`--build-file` is a [Gradle CLI option](https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:environment_options) that specifies the file name of the project file (typically `build.gradle` or `build.gradle.kts`). The Gradle CLI plugin uses `--build-file` to point Gradle to the right build file so it can extract the specific depgraph belonging to the corresponding project.

`--build-file` was deprecated in Gradle 8.x and removed in Gradle 9.0. Because of the latter, Gradle CLI plugin now fails in Gradle 9.0.

`--project-dir` is another Gradle CLI option that points Gradle to the directory of the project, functionally it is similar to `--build-file` and in our setting it is a full replacement. It is available in Gradle since the very early versions.

A Gradle project can in principle reside in any Gradle file, but conventionally is it in `build.gradle`. Without specifying `--build-file`, Gradle picks up `build.gradle` (and if that is not found - `build.gradle.kts`). The reason for deprecating `--build-file` is that Gradle [encourages](https://discuss.gradle.org/t/deprecation-of-build-file-for-specifying-a-custom-build-file-location-in-8-0/41244) its users to follow a standard file naming convention.

Snyk CLI only discovers target files `build.gradle` and `build.gradle.kts` before giving them to the Gradle plugin. So, it was never called with custom-named target files in the first place. Therefore it is safe to replace `--build-file` with `--project-dir`.

## Refactor Groovy tests

Groovy 9.0.0 removed several deprecated Gradle APIs, so the existing tests had to be refactored accordingly. In particular:
* The `jcenter()` repo was shut down are removed from the API - replace it with `mavenCentral()`.
* Top-level assignments to `sourceCompatibility` and `targetCompatibility` are moved to the `java` block.
* Top-level assignment to `mainClassName` is no longer supported in Gradle 9, replace with `application.mainClass.set`. 

## New Kotlin test

There are two reasons for it:
* I could not find a clean enough way to detect the Kotlin version inside the `build.gradle.kts` that would be compatible with all tested Gradle versions.
* The test asserts in `kotlin.test.ts` need to be tweaked for Gradle 9 anyway, because there are several big changes in the 2.x release of Kotlin. E.g. `org.jetbrains.kotlin:kotlin-stdlib-common` was renamed to `org.jetbrains.kotlin:kotlin-stdlib` and we get whole other direct deps of `org.jetbrains.kotlin:kotlin-stdlib-jdk8` in the test.