### PR TITLE
chore: Add Gradle 9.1.0-rc-3 to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ test_matrix_unix_new_versions: &test_matrix_unix_new_versions
     parameters:
       node_version: [ '16.18', '18.18', '20.9' ]
       jdk_version: [ '17.0.9-jbr' ]
-      gradle_version: [ '7.3', '8.4', '9.0.0' ]
+      gradle_version: [ '7.3', '8.4', '9.0.0', '9.1.0-rc-3' ]
 
 test_matrix_win: &test_matrix_win
   matrix:


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy

### What this does

Adds running the CI/CD pipeline against Gradle 9.1.0-rc-3 for Linux.
RC is not available via Chocolatey for Windows.
