### PR TITLE
fix: filter out configs without deps

### DIFF
--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -272,20 +272,46 @@ def findProjectConfigs(proj, confNameFilter, confAttrSpec) {
     debugLog("resolvableConfigs=$resolvable")
     return resolvable
 }
+
+// Only include configurations that actually have dependencies
+def hasResolvableDependencies(config, resolvableConfigs) {
+    def resolvableDependencies = []
+    // Does this dependency come from a resolvable configuration?
+    config.firstLevelModuleDependencies.each { dep ->
+        def isResolvableDependency = resolvableConfigs.any { conf -> conf.name == dep.configuration }
+        if (isResolvableDependency) {
+            resolvableDependencies.add(dep)
+        }
+    }
+    
+    if (resolvableDependencies.isEmpty()) {
+        return false
+    }
+    return true
+}
+
 List getResolvedConfigs(resolvableConfigs){
     List resolvedConfigs = []
     resolvableConfigs.each({ config ->
         ResolvedConfiguration resConf = config.getResolvedConfiguration()
         debugLog("config `$config.name' resolution has errors: ${resConf.hasError()}")
         if (!resConf.hasError()) {
-            resolvedConfigs.add(resConf)
-            debugLog("Fully resolved config `$config.name' with deps: $resConf.firstLevelModuleDependencies")
+            if (hasResolvableDependencies(resConf, resolvableConfigs)) {
+                resolvedConfigs.add(resConf)
+                debugLog("Fully resolved config `$config.name' with deps: $resConf.firstLevelModuleDependencies")
+            } else {
+                debugLog("Skipping resolved config `$config.name' no resolvable dependencies found")
+            }
         } else {
             // even if some dependencies fail to resolve, we prefer a partial result to none
             LenientConfiguration lenientConf = resConf.getLenientConfiguration()
-            debugLog("Partially resolved config `$config.name' with: $lenientConf.firstLevelModuleDependencies")
-            debugLog("Couldn't resolve: ${lenientConf.getUnresolvedModuleDependencies()}")
-            resolvedConfigs.add(lenientConf)
+            if (hasResolvableDependencies(lenientConf, resolvableConfigs)) {
+                resolvedConfigs.add(lenientConf)
+                debugLog("Partially resolved config `$config.name' with: $lenientConf.firstLevelModuleDependencies")
+                debugLog("Couldn't resolve: ${lenientConf.getUnresolvedModuleDependencies()}")
+            } else {
+                debugLog("Skipping lenient config `$config.name' no resolvable dependencies found")
+            }
         }
     })
     return resolvedConfigs
@@ -379,11 +405,6 @@ allprojects { Project currProj ->
 
                 def resolvableConfigs = findProjectConfigs(proj, confNameFilter, confAttrSpec)
                 List resolvedConfigs = getResolvedConfigs(resolvableConfigs)
-
-                if (resolvedConfigs.isEmpty() && !resolvableConfigs.isEmpty()) {
-                    throw new RuntimeException('Configurations: ' + resolvableConfigs.collect { it.name } +
-                            ' for project ' + proj + ' could not be resolved.')
-                }
                 List nonemptyFirstLevelDeps = []
                 resolvedConfigs.each { nonemptyFirstLevelDeps.addAll(it.getFirstLevelModuleDependencies()) }
 
@@ -481,11 +502,6 @@ allprojects { Project currProj ->
 
                 def resolvableConfigs = findProjectConfigs(proj, confNameFilter, confAttrSpec)
                 List resolvedConfigs = getResolvedConfigs(resolvableConfigs)
-                if (!resolvableConfigs.isEmpty() && resolvedConfigs.isEmpty()) {
-                    throw new RuntimeException('Configurations: ' + resolvableConfigs.collect { it.name } +
-                            ' for project ' + proj + ' could not be resolved.')
-                }
-
                 List nonemptyFirstLevelDeps = []
                 resolvedConfigs.each { nonemptyFirstLevelDeps.addAll(it.getFirstLevelModuleDependencies()) }
 

--- a/test/fixtures/multi-project-compile/README.md
+++ b/test/fixtures/multi-project-compile/README.md
@@ -1,0 +1,5 @@
+# multi-project-compile
+
+This test fixture ensures we only resolve a single version of 'tomcat-embed-core' when one subproject depends on another using the 'compile' configuration.
+
+Changes made to the init.gradle now ensure empty configurations and dependencies that come from non-resolvable configurations are ignored.

--- a/test/fixtures/multi-project-compile/build.gradle
+++ b/test/fixtures/multi-project-compile/build.gradle
@@ -1,0 +1,5 @@
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/test/fixtures/multi-project-compile/settings.gradle
+++ b/test/fixtures/multi-project-compile/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'root-proj'
+include 'subproj-a', 'subproj-b'

--- a/test/fixtures/multi-project-compile/subproj-a/build.gradle
+++ b/test/fixtures/multi-project-compile/subproj-a/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'java-library'
+    id 'org.springframework.boot' version '2.7.18'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+}
+
+bootJar {
+    enabled = false
+}
+
+dependencies {
+    compile project(':subproj-b')
+    implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.99'
+}

--- a/test/fixtures/multi-project-compile/subproj-b/build.gradle
+++ b/test/fixtures/multi-project-compile/subproj-b/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java-library'
+    id 'org.springframework.boot' version '2.7.18'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+}
+
+bootJar {
+    enabled = false
+}
+
+dependencies {
+    implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.99'
+}

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -649,4 +649,31 @@ describe('multi-project', () => {
       'module/tools',
     ]);
   });
+
+  test('multi-project-compile: ignores empty configurations and dependencies that are not resolvable', async () => {
+    const result = await inspect(
+      '.',
+      path.join(fixtureDir('multi-project-compile'), 'build.gradle'),
+      { allSubProjects: true },
+    );
+
+    expect(result.scannedProjects.length).toBe(3);
+
+    const allDependencies = new Set<string>();
+    for (const project of result.scannedProjects) {
+      const pkgs = project.depGraph?.getDepPkgs() || [];
+      Object.keys(pkgs).forEach((id) => {
+        allDependencies.add(`${pkgs[id].name}@${pkgs[id].version}`);
+      });
+    }
+
+    // Check that we only have one version of tomcat-embed-core
+    const tomcatVersions = Array.from(allDependencies).filter((dep) =>
+      dep.startsWith('org.apache.tomcat.embed:tomcat-embed-core@'),
+    );
+
+    expect(tomcatVersions).toEqual([
+      'org.apache.tomcat.embed:tomcat-embed-core@9.0.99',
+    ]);
+  });
 });


### PR DESCRIPTION
- [X] Tests written and linted
- [X] Documentation written
- [X] Commit history is tidy

### What this does

Before using a configuration, check that it has resolvable dependencies. Each configuraiton must have at least one firstLevelModuleDependencies that comes from a resolvable configuration.

This filters out deprecated configurations, like compile and runtime.

By allowing these configurations to be processed we incorrectly resolve dependencies for them.

