### PR TITLE
chore: Use Gradle 9.1.0 in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ test_matrix_unix_new_versions: &test_matrix_unix_new_versions
     parameters:
       node_version: [ '16.18', '18.18', '20.9' ]
       jdk_version: [ '17.0.9-jbr' ]
-      gradle_version: [ '7.3', '8.4', '9.0.0', '9.1.0-rc-3' ]
+      gradle_version: [ '7.3', '8.4', '9.1.0' ]
 
 test_matrix_win: &test_matrix_win
   matrix:
@@ -55,7 +55,7 @@ test_matrix_win_new_versions: &test_matrix_win_new_versions
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '17.0.2' ]
       jdk_path: [ 'C:\Program Files\OpenJDK\jdk-17.0.2' ]
-      gradle_version: [ '7.3', '8.4', '9.0.0' ]
+      gradle_version: [ '7.3', '8.4', '9.1.0' ]
 
 filters_branches_only_main: &filters_branches_only_main
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ defaults: &defaults
     jdk_version:
       type: string
       default: ''
-    jdk_path:
-      type: string
-      default: ''
     node_version:
       type: string
       default: ''
@@ -46,7 +43,6 @@ test_matrix_win: &test_matrix_win
     parameters:
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '8' ]
-      jdk_path: [ 'C:\Program Files\Eclipse Adoptium\jdk-8.0.442.6-hotspot' ]
       gradle_version: [ '4.10', '5.5', '6.2.1' ]
 
 test_matrix_win_new_versions: &test_matrix_win_new_versions
@@ -54,7 +50,6 @@ test_matrix_win_new_versions: &test_matrix_win_new_versions
     parameters:
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '17.0.2' ]
-      jdk_path: [ 'C:\Program Files\OpenJDK\jdk-17.0.2' ]
       gradle_version: [ '7.3', '8.4', '9.1.0' ]
 
 filters_branches_only_main: &filters_branches_only_main
@@ -181,7 +176,7 @@ commands:
       - restore_cache:
           name: Restoring Java binary from cache
           keys:
-            - chocolatey-jdk-cache-{{ arch }}-v4
+            - chocolatey-jdk-cache-{{ arch }}-v5
       - run:
           name: Installing JDK
           command: |
@@ -191,7 +186,7 @@ commands:
               choco install --force -y openjdk --version=<< parameters.jdk_version >> --cache ~\AppData\Local\Temp\jdk
             fi
       - save_cache:
-          key: chocolatey-jdk-cache-{{ arch }}-v4
+          key: chocolatey-jdk-cache-{{ arch }}-v5
           paths:
             - ~\AppData\Local\Temp\jdk
 jobs:
@@ -229,7 +224,6 @@ jobs:
     <<: *windows_defaults
     environment:
       JDK: << parameters.jdk_version >>
-      JAVA_HOME: << parameters.jdk_path >>
       npm_config_loglevel: silent
       GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.daemon.idletimeout=180000 -Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process'
       JAVA_OPTS: ' -Xmx512M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
@@ -247,9 +241,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export JAVA_HOME="<< parameters.jdk_path >>"
-            export PATH=$JAVA_HOME/bin:$PATH
-             if [[ << parameters.jdk_version >> == "8" ]]; then
+            if [[ << parameters.jdk_version >> == "8" ]]; then
               java -version
             else
               java --version


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written
- [x] Commit history is tidy

### What this does
Swaps from using Gradle 9.0.0 to 9.1.0 in CI/CD, as well as removing testing against the release candidate.

