### PR TITLE
fix: use relative path rather than filename in targetFile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ test_matrix_unix_new_versions: &test_matrix_unix_new_versions
     parameters:
       node_version: [ '16.18', '18.18', '20.9' ]
       jdk_version: [ '17.0.9-jbr' ]
-      gradle_version: [ '7.3', '8.4', '9.0.0', '9.1.0-rc-3' ]
+      gradle_version: [ '7.3', '8.4', '9.0.0', '9.2.0' ]
 
 test_matrix_win: &test_matrix_win
   matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ defaults: &defaults
     jdk_version:
       type: string
       default: ''
-    jdk_path:
-      type: string
-      default: ''
     node_version:
       type: string
       default: ''
@@ -46,7 +43,6 @@ test_matrix_win: &test_matrix_win
     parameters:
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '8' ]
-      jdk_path: [ 'C:\Program Files\Eclipse Adoptium\jdk-8.0.442.6-hotspot' ]
       gradle_version: [ '4.10', '5.5', '6.2.1' ]
 
 test_matrix_win_new_versions: &test_matrix_win_new_versions
@@ -54,7 +50,6 @@ test_matrix_win_new_versions: &test_matrix_win_new_versions
     parameters:
       node_version: [ '16', '18', '20' ]
       jdk_version: [ '17.0.2' ]
-      jdk_path: [ 'C:\Program Files\OpenJDK\jdk-17.0.2' ]
       gradle_version: [ '7.3', '8.4', '9.0.0' ]
 
 filters_branches_only_main: &filters_branches_only_main
@@ -190,6 +185,19 @@ commands:
             else
               choco install --force -y openjdk --version=<< parameters.jdk_version >> --cache ~\AppData\Local\Temp\jdk
             fi
+      - run:
+          name: Set JAVA_HOME
+          command: |
+            # Find the JDK we just installed by matching the version parameter
+            JDK_MAJOR=$(echo "<< parameters.jdk_version >>" | cut -d. -f1)
+            if [[ << parameters.jdk_version >> == "8" ]]; then
+              JDK_DIR="C:/Program Files/Eclipse Adoptium"
+            else
+              JDK_DIR="C:/Program Files/OpenJDK"
+            fi
+            JAVA_HOME=$(powershell -Command "(Get-ChildItem \"$JDK_DIR\" -Directory -Filter \"jdk-$JDK_MAJOR*\" -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1).FullName")
+            echo "export JAVA_HOME=\"$JAVA_HOME\"" >> $BASH_ENV
+            echo "export PATH=\"$JAVA_HOME/bin:\$PATH\"" >> $BASH_ENV
       - save_cache:
           key: chocolatey-jdk-cache-{{ arch }}-v4
           paths:
@@ -229,7 +237,6 @@ jobs:
     <<: *windows_defaults
     environment:
       JDK: << parameters.jdk_version >>
-      JAVA_HOME: << parameters.jdk_path >>
       npm_config_loglevel: silent
       GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.daemon.idletimeout=180000 -Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dkotlin.compiler.execution.strategy=in-process'
       JAVA_OPTS: ' -Xmx512M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
@@ -247,9 +254,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export JAVA_HOME="<< parameters.jdk_path >>"
-            export PATH=$JAVA_HOME/bin:$PATH
-             if [[ << parameters.jdk_version >> == "8" ]]; then
+            if [[ << parameters.jdk_version >> == "8" ]]; then
               java -version
             else
               java --version

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -280,15 +280,17 @@ async function getAllDepsAllProjects(
       projectId === defaultProject
         ? defaultProject
         : `${defaultProject}/${projectId}`;
+
+    const absoluteTargetFile = allProjectDeps.projects[projectId].targetFile;
+    const relativeTargetFile = path.relative(root, absoluteTargetFile);
+
     return {
-      targetFile: targetFileFilteredForCompatibility(
-        allProjectDeps.projects[projectId].targetFile,
-      ),
+      targetFile: relativeTargetFile,
       meta: {
         gradleProjectName,
         projectName: gradleProjectName,
         versionBuildInfo: allProjectDeps.versionBuildInfo,
-        targetFile: allProjectDeps.projects[projectId].targetFile,
+        targetFile: absoluteTargetFile,
       },
       depGraph: allProjectDeps.projects[projectId].depGraph,
     };

--- a/test/system/multi-module.test.ts
+++ b/test/system/multi-module.test.ts
@@ -195,9 +195,11 @@ describe('multi-project', () => {
         // return the deps nodeIds list that belongs to a node
         const graphObject: any = JSON.parse(JSON.stringify(p.depGraph));
         expect(graphObject.graph.nodes[0].deps.length).toBe(0);
-        expect(p.targetFile).toBeFalsy(); // see targetFileFilteredForCompatibility
-        // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-        // expect(p.targetFile, 'multi-project' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
+        const expectedTargetFile = path.relative(
+          '.',
+          path.join(multiProject, 'build.gradle'),
+        );
+        expect(p.targetFile).toBe(expectedTargetFile);
       } else {
         expect(p.depGraph.rootPkg.name).toBe('root-proj/subproj');
         expect(p.meta?.gradleProjectName).toBe('root-proj/subproj');
@@ -212,9 +214,11 @@ describe('multi-project', () => {
           nodeIds.indexOf('com.android.tools:annotations@25.3.0'),
         ).toBeGreaterThanOrEqual(-1);
 
-        expect(p.targetFile).toBeFalsy(); // see targetFileFilteredForCompatibility
-        // TODO(kyegupov): when the project name issue is solved, change the assertion to:
-        // expect(p.targetFile, 'subproj' + dirSep + 'build.gradle', 'correct targetFile for the main depRoot');
+        const expectedTargetFile = path.relative(
+          '.',
+          path.join(multiProject, 'subproj', 'build.gradle'),
+        );
+        expect(p.targetFile).toBe(expectedTargetFile);
       }
     }
   });
@@ -241,6 +245,11 @@ describe('multi-project', () => {
     expect(
       nodeIds.indexOf('commons-httpclient:commons-httpclient@3.1'),
     ).toBeGreaterThanOrEqual(-1);
+    const expectedTargetFile = path.relative(
+      '.',
+      path.join(fixtureDir('api-configuration'), 'build.gradle'),
+    );
+    expect(result.scannedProjects[0].targetFile).toBe(expectedTargetFile);
   });
 
   test('multi-project-some-unscannable: gradle-sub-project for a good subproject works', async () => {


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written - n/a
- [x] Commit history is tidy

### What this does

A customer reported an issue when running `snyk test --all-projects --sarif` against a Gradle repo, where the `artifactLocation` in the output was only showing the filename e.g.

```
                  "artifactLocation": {
                    "uri": "build.gradle"
                  },
```

rather than the relative path including directories e.g.

```
                  "artifactLocation": {
                    "uri": "subproject2/build.gradle"
                  },
```

This PR fixes that issue by removing a call to `targetFileFilteredForCompatibility`, which I believe is a hack that is no longer needed (but it would be great for someone to confirm this!), and replaces it by just getting the relative path to the file.

I have kept the call to `targetFileFilteredForCompatibility` [here](https://github.com/snyk/snyk-gradle-plugin/blob/557de77/lib/index.ts#L93) (used by Registry to generate the project name as shown [here](https://github.com/snyk/registry/blob/3b654c6/src/web/routes/api/v1/test/dep-graph.ts#L115-L120)) to ensure that it doesn't cause any issues there.

Note that I've also had to resolve some issues in the CircleCI config to get the pipeline to pass:
- Replaced the reference to Gradle version `9.1.0-rc-3` (which the pipeline can't pull down any more) with `9.2.0`
- Removed the manual overriding of `JAVA_HOME`

#### How should this be manually tested?

1. Clone the repo [here](https://github.com/Snyk-General-Support/00110191/tree/main/multi-project-hello-world)
2. Run `snyk test --all-projects --sarif` against that repo and you should see `artifactLocation` as `build.gradle` in all cases including the subprojects
3. Build the CLI pointing to this branch of the Gradle plugin and run the same again, and now you should see the subproject directories where relevant e.g. `subproject2/build.gradle`.

[OSM-3010]: https://snyksec.atlassian.net/browse/OSM-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ