### PR TITLE
fix: Use node 24 for lint/security/release stages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ windows_defaults: &windows_defaults
 test_matrix_unix: &test_matrix_unix
   matrix:
     parameters:
-      node_version: [ '20.20', '22.22', '24.15' ]
+      node_version: [ '20.20', '22.22', '24.16' ]
       jdk_version: [ '8.0.292.j9-adpt' ]
       gradle_version: [ '4.10', '5.5', '6.2.1']
 
 test_matrix_unix_new_versions: &test_matrix_unix_new_versions
   matrix:
     parameters:
-      node_version: [ '20.20', '22.22', '24.15' ]
+      node_version: [ '20.20', '22.22', '24.16' ]
       jdk_version: [ '17.0.9-jbr' ]
       gradle_version: [ '7.3', '8.4', '9.0.0', '9.2.0' ]
 
@@ -309,7 +309,7 @@ workflows:
 
       - security-scans:
           name: Security Scans
-          node_version: "22.22"
+          node_version: "24.16"
           context:
             - open_source-managed
             - nodejs-install
@@ -317,7 +317,7 @@ workflows:
       - lint:
           name: Lint
           context: nodejs-install
-          node_version: '22.22'
+          node_version: '24.16'
           <<: *filters_branches_ignore_main
 
       - test-unix:
@@ -357,5 +357,5 @@ workflows:
           context:
             - nodejs-install
             - github-release
-          node_version: '22.22'
+          node_version: '24.16'
           <<: *filters_branches_only_main


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written
- [ ] Commit history is tidy

### What this does

OIDC publishing support evidently requires npm v11.5+
Swap to using `node:24.16` images for release, etc. which should come with npm v11.13.0