### PR TITLE
feat: add includeComponentMetadata support to Gradle resolver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,15 @@ commands:
       - run:
           name: Install Java 21 for Gradle toolchain support
           command: |
-            if [[ "<< parameters.jdk_version >>" == "8.0.292.j9-adpt" ]]; then
-              sdk install java 21.0.5-tem || true
+            JDK_MAJOR=$(echo "<< parameters.jdk_version >>" | cut -d. -f1)
+            if [[ "$JDK_MAJOR" == "8" ]]; then
+              # Tolerate a non-zero exit when 21 is already present from cache,
+              # but hard-fail if the toolchain genuinely isn't installed rather
+              # than letting Gradle fail later with an opaque provisioning error.
+              if ! sdk install java 21.0.5-tem && [ ! -d "$HOME/.sdkman/candidates/java/21.0.5-tem" ]; then
+                echo "Failed to install Java 21 toolchain for Gradle" >&2
+                exit 1
+              fi
               sdk default java << parameters.jdk_version >>
             fi
       - save_cache:

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -9,6 +9,9 @@ export interface GradleGraph {
     name: string;
     version: string;
     parentIds: string[];
+    // Populated by init.gradle only under -PsnykIncludeComponentMetadata.
+    hashes?: Record<string, string>;
+    distributionUrl?: string;
   };
 }
 
@@ -133,7 +136,10 @@ export async function buildGraph(
       depGraphBuilder.addPkgNode(
         { name, version },
         id,
-        createNodeInfo(pkgIdProvenance),
+        createNodeInfo(pkgIdProvenance, undefined, {
+          hashes: node.hashes,
+          distributionUrl: node.distributionUrl,
+        }),
       );
       depGraphBuilder.connectDep(parentId, id);
       visitedMap[id] = { name, version };
@@ -151,9 +157,25 @@ export async function buildGraph(
 function createNodeInfo(
   pkgIdProvenance?: string,
   pruned?: 'cyclic' | 'true',
+  componentMetadata?: {
+    hashes?: Record<string, string>;
+    distributionUrl?: string;
+  },
 ): { labels: Record<string, string> } | undefined {
   const labels: Record<string, string> = {};
   if (pruned) labels.pruned = pruned;
   if (pkgIdProvenance) labels.pkgIdProvenance = pkgIdProvenance;
+  // Component-metadata labels use the shared cross-ecosystem vocabulary
+  // (hash:<alg>, distribution:url) so SBOM generation can consume them
+  // identically to Maven/npm. Present only when init.gradle emitted them.
+  if (componentMetadata) {
+    const { hashes, distributionUrl } = componentMetadata;
+    if (hashes) {
+      for (const [alg, value] of Object.entries(hashes)) {
+        if (value) labels[`hash:${alg}`] = value;
+      }
+    }
+    if (distributionUrl) labels['distribution:url'] = distributionUrl;
+  }
   return Object.keys(labels).length ? { labels } : undefined;
 }

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -166,8 +166,7 @@ function createNodeInfo(
   if (pruned) labels.pruned = pruned;
   if (pkgIdProvenance) labels.pkgIdProvenance = pkgIdProvenance;
   // Component-metadata labels use the shared cross-ecosystem vocabulary
-  // (hash:<alg>, distribution:url) so SBOM generation can consume them
-  // identically to Maven/npm. Present only when init.gradle emitted them.
+  // (hash:<alg>, distribution:url). Present only when init.gradle emitted them.
   if (componentMetadata) {
     const { hashes, distributionUrl } = componentMetadata;
     if (hashes) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -671,6 +671,17 @@ function buildArgs(
     args.push(`-PconfAttr=${options['configuration-attributes']}`);
   }
 
+  // Opt-in component-metadata labels (hash:<alg>, distribution:url). The init
+  // script only does the extra work when this property is present.
+  if (options.includeComponentMetadata) {
+    args.push('-PsnykIncludeComponentMetadata=true');
+    // Forces network re-validation of metadata so distribution:url can be
+    // captured on a warm cache. Only meaningful alongside the metadata flag.
+    if (options.gradleRefreshDependencies) {
+      args.push('--refresh-dependencies');
+    }
+  }
+
   if (options.initScript) {
     const formattedInitScript = path.resolve(options.initScript);
     args.push('--init-script', formattedInitScript);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -687,8 +687,13 @@ function buildArgs(
     args.push('--init-script', formattedInitScript);
   }
 
-  const isWin = /^win/.test(os.platform());
-  if (isWin && !options.daemon) {
+  // Default to a fresh, one-shot JVM unless a daemon is explicitly requested.
+  // On Windows a daemon otherwise leaves the process hanging from Node's
+  // standpoint; on Unix a reused daemon accumulates heap across repeated
+  // invocations (e.g. a full test suite run), which under a memory-constrained
+  // runner tips it into an OOM kill. A single one-shot scan gains nothing from
+  // the daemon, so opt out on every platform.
+  if (!options.daemon) {
     args.push('--no-daemon');
   }
 

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -126,15 +126,28 @@ class Sha1Map {
 // `algorithms` maps the JDK algorithm name to its output label; returns
 // {label: lowercase-hex}. Shared by every file-hashing helper below.
 def digestFile(File file, Map<String, String> algorithms) {
-    def digests = algorithms.collectEntries { javaName, _label ->
-        [(javaName): java.security.MessageDigest.getInstance(javaName)]
+    def javaNames = algorithms.keySet().toList()
+    def mds = javaNames.collect { java.security.MessageDigest.getInstance(it) }
+    // Reuse a single 64 KB buffer for the whole file. Groovy's
+    // File.eachByte(int, Closure) allocates a fresh byte[] copy per chunk, so
+    // hashing large artifacts churns enough short-lived garbage to inflate the
+    // Gradle daemon's peak heap; a manual read loop keeps allocation ~constant.
+    // Digests are identical either way — MessageDigest is chunking-invariant.
+    // All state is local, so this stays safe under parallel per-project tasks.
+    byte[] buffer = new byte[64 * 1024]
+    file.withInputStream { input ->
+        int read
+        while ((read = input.read(buffer)) != -1) {
+            for (md in mds) {
+                md.update(buffer, 0, read)
+            }
+        }
     }
-    file.eachByte(1024 * 8) { buffer, len ->
-        digests.each { _name, md -> md.update(buffer, 0, len) }
+    def result = [:]
+    javaNames.eachWithIndex { javaName, i ->
+        result[algorithms[javaName]] = mds[i].digest().encodeHex().toString()
     }
-    return digests.collectEntries { javaName, md ->
-        [(algorithms[javaName]): md.digest().encodeHex().toString()]
-    }
+    return result
 }
 
 // SHA-1 hex of a file's contents (normalized-mode node id).

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -166,17 +166,23 @@ def computeHashes(File file) {
     return result
 }
 
-// Strip any userinfo (basic-auth credentials) from a URL before labelling, so
-// private-registry credentials never leak into the dep-graph. Mirrors
-// nodejs-lockfile-parser's component-metadata credential stripping.
-def stripCredentials(String url) {
+// Reduce a resource URL to its canonical, credential-free location —
+// scheme://host[:port]/path — by parsing it as a URI and dropping userInfo,
+// query and fragment. The query is where URL-borne auth lives (Azure Blob SAS
+// tokens, GCS/S3 signed-URL signatures); it is request-scoped and never part
+// of the artifact's durable location, so it is dropped wholesale rather than
+// by enumerating credential parameter names. Basic-auth userInfo is dropped
+// for the same reason. Operating on the parsed URI (not string surgery) keeps
+// the rule single and robust.
+def canonicalUrl(String url) {
     try {
         def u = new URI(url)
-        if (u.userInfo != null) {
-            return new URI(u.scheme, null, u.host, u.port, u.path, u.query, u.fragment).toString()
-        }
-    } catch (Exception ignored) { /* not a parseable URI — return as-is */ }
-    return url
+        return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
+    } catch (Exception ignored) {
+        // Unparseable — still make a best effort to drop query/fragment so a
+        // token in the query can never survive into a label.
+        return url.replaceAll(/[?#].*$/, '')
+    }
 }
 
 // Register an internal build-operation listener that records the URL of every
@@ -215,13 +221,18 @@ def recordResourceRead(buildOp) {
         if (loc == null) return
         def url = loc.toString()
         if (!(url.startsWith('http://') || url.startsWith('https://'))) return
-        def clean = url.replaceAll(/[?#].*$/, '')
-        int slash = clean.lastIndexOf('/')
-        if (slash < 0 || slash == clean.length() - 1) return
-        def filename = clean.substring(slash + 1)
+        def uri
+        try { uri = new URI(url) } catch (Exception ignored) { return }
+        // Derive the filename from the parsed path (already free of query and
+        // fragment), then store the canonicalised, credential-free URL.
+        def path = uri.path
+        if (!path) return
+        int slash = path.lastIndexOf('/')
+        if (slash < 0 || slash == path.length() - 1) return
+        def filename = path.substring(slash + 1)
         snykUrlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
-            .add(stripCredentials(url))
+            .add(canonicalUrl(url))
     } catch (Exception ignored) { /* one bad op must not break resolution */ }
 }
 
@@ -266,7 +277,13 @@ def lookupDistributionUrl(String name, String version, String fileName) {
         def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
         def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
         def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
-        def matches = candidates.findAll { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        def matches = candidates.findAll { candidate ->
+            try {
+                return new URI(candidate).path?.endsWith(suffix)
+            } catch (Exception ignored) {
+                return false
+            }
+        }
         if (matches.size() == 1) return matches[0]
     } catch (Exception ignored) { /* fall through to no-label */ }
     return null

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -1,4 +1,5 @@
 import groovy.json.JsonOutput
+import groovy.transform.Field
 import java.util.regex.Pattern
 import java.util.regex.Matcher
 import org.gradle.util.GradleVersion
@@ -64,13 +65,20 @@ class GradleGraph {
         this.rootId = rootId
     }
 
-    Map setNode(String key, Map value) {
+    Map setNode(String key, Map value, Map metadata = null) {
         if (!key || !value) {
             return null
         }
 
         nodes.computeIfAbsent(key) { _ ->
-            ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
+            def node = ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
+            // Component metadata (opt-in via -PsnykIncludeComponentMetadata). Only
+            // the first emission of a nodeId wins — consistent with name/version.
+            if (metadata) {
+                if (metadata.hashes) node.hashes = metadata.hashes
+                if (metadata.distributionUrl) node.distributionUrl = metadata.distributionUrl
+            }
+            node
         }
     }
 
@@ -119,6 +127,139 @@ def hash(File file) {
 def hashString(String str) {
     def md = java.security.MessageDigest.getInstance('SHA-1')
     return md.digest(str.bytes).encodeHex().toString()
+}
+
+// ── Component metadata (opt-in: -PsnykIncludeComponentMetadata) ──────────────
+// Emits the same node-label vocabulary as snyk-mvn-plugin / nodejs-lockfile-parser:
+//   hash:<alg>       lowercase-hex digests of the resolved artifact file
+//   distribution:url the real remote URL Gradle read the artifact from
+// distribution:url is TRUE provenance only — Gradle exposes no per-artifact
+// source repository in its public API, so we capture the actual resource-read
+// URLs via an internal build-operation listener (see registerResourceReadListener).
+// On a warm cache nothing is re-fetched, so a node simply carries no
+// distribution:url — graceful omission, never a reconstructed guess.
+
+// @Field so the standalone `def` helpers below (buildArtifactMetadata etc.)
+// can read this shared state — run()-scope locals aren't visible to methods,
+// and bare assignments in an init script route to the Gradle object.
+@Field boolean snykIncludeComponentMetadata = false
+// filename -> Set<url>. A Set because a shared cache can see the same filename
+// from more than one repo across a build; disambiguated at lookup by layout.
+@Field def snykUrlsByFilename = new java.util.concurrent.ConcurrentHashMap()
+
+// Compute md5/sha-1/sha-256/sha-512 in a single pass over the file bytes.
+// Keys match the CycloneDX-friendly label suffixes used across ecosystems.
+def computeHashes(File file) {
+    def algos = ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512']
+    def digests = algos.collectEntries { javaName, _label -> [(javaName): java.security.MessageDigest.getInstance(javaName)] }
+    file.eachByte(1024 * 8) { buffer, len ->
+        digests.each { _name, md -> md.update(buffer, 0, len) }
+    }
+    def result = [:]
+    digests.each { javaName, md -> result[algos[javaName]] = md.digest().encodeHex().toString() }
+    return result
+}
+
+// Strip any userinfo (basic-auth credentials) from a URL before labelling, so
+// private-registry credentials never leak into the dep-graph. Mirrors
+// nodejs-lockfile-parser's component-metadata credential stripping.
+def stripCredentials(String url) {
+    try {
+        def u = new URI(url)
+        if (u.userInfo != null) {
+            return new URI(u.scheme, null, u.host, u.port, u.path, u.query, u.fragment).toString()
+        }
+    } catch (Exception ignored) { /* not a parseable URI — return as-is */ }
+    return url
+}
+
+// Register an internal build-operation listener that records the URL of every
+// external resource Gradle reads during resolution. This is the ONLY signal
+// that carries true per-artifact provenance; the public resolution/artifact
+// API deliberately omits it. Internal + unstable across Gradle versions, so
+// the whole thing is best-effort: any failure degrades to "no distribution:url".
+def registerResourceReadListener() {
+    try {
+        def manager = gradle.services.get(org.gradle.internal.operations.BuildOperationListenerManager)
+        // Map-of-closures coerced to the interface: closures take untyped args,
+        // so this satisfies the interface's typed abstract methods on every
+        // Gradle version (the method set has changed — e.g. progress() was added
+        // later). Methods absent from the map become harmless no-ops.
+        def listener = [
+            started : { buildOp, startEvent -> },
+            progress: { operationId, progressEvent -> },
+            finished: { buildOp, finishEvent -> recordResourceRead(buildOp) },
+        ] as org.gradle.internal.operations.BuildOperationListener
+        manager.addListener(listener)
+        debugLog('component-metadata: resource-read listener registered')
+    } catch (Exception e) {
+        debugLog("component-metadata: listener registration failed (${e.class.simpleName}: ${e.message}); distribution:url unavailable")
+    }
+}
+
+// Record the URL of one finished build operation if it is an external-resource
+// read. Duck-typed on getLocation() to avoid importing the internal details
+// type (whose package has moved across Gradle versions).
+def recordResourceRead(buildOp) {
+    try {
+        def details = buildOp?.details
+        if (details == null) return
+        if (!details.metaClass.respondsTo(details, 'getLocation')) return
+        def loc = details.getLocation()
+        if (loc == null) return
+        def url = loc.toString()
+        if (!(url.startsWith('http://') || url.startsWith('https://'))) return
+        def clean = url.replaceAll(/[?#].*$/, '')
+        int slash = clean.lastIndexOf('/')
+        if (slash < 0 || slash == clean.length() - 1) return
+        def filename = clean.substring(slash + 1)
+        snykUrlsByFilename
+            .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
+            .add(stripCredentials(url))
+    } catch (Exception ignored) { /* one bad op must not break resolution */ }
+}
+
+// Read the requested -P property at init time; project properties surface on
+// the start parameter before any project is evaluated.
+snykIncludeComponentMetadata = gradle.startParameter.projectProperties.containsKey('snykIncludeComponentMetadata')
+if (snykIncludeComponentMetadata) {
+    registerResourceReadListener()
+}
+
+// Build the per-node metadata map for a resolved artifact: file hashes plus,
+// when we observed the real read, its distribution:url. Returns null when the
+// flag is off or nothing could be derived (e.g. no artifact file).
+def buildArtifactMetadata(artifact, String name, String version) {
+    if (!snykIncludeComponentMetadata) return null
+    try {
+        def file = artifact?.file
+        if (file == null || !file.isFile()) return null
+        def meta = ['hashes': computeHashes(file)]
+        def url = lookupDistributionUrl(name, version, file.name)
+        if (url) meta.distributionUrl = url
+        return meta
+    } catch (Exception e) {
+        debugLog("component-metadata: failed for ${name}@${version}: ${e.message}")
+        return null
+    }
+}
+
+// Resolve a filename to the URL it was actually read from. When a filename maps
+// to more than one captured URL (shared cache seeing multiple repos), pick the
+// one whose path matches this artifact's Maven layout; if still ambiguous,
+// emit nothing rather than guess.
+def lookupDistributionUrl(String name, String version, String fileName) {
+    def candidates = snykUrlsByFilename.get(fileName)
+    if (!candidates || candidates.isEmpty()) return null
+    if (candidates.size() == 1) return candidates.iterator().next()
+    try {
+        def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
+        def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
+        def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
+        def match = candidates.find { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        if (match) return match
+    } catch (Exception ignored) { /* fall through to no-label */ }
+    return null
 }
 
 // Walks each resolvable configuration via Gradle's modern resolution APIs:
@@ -256,7 +397,7 @@ def walkComponent(component, GradleGraph graph, String parentId,
                     nodeId = coordinate
                     coordToNodeId[coordinate] = nodeId
                 }
-                graph.setNode(nodeId, ['name': name, 'version': version])
+                graph.setNode(nodeId, ['name': name, 'version': version], buildArtifactMetadata(a, name, version))
                 graph.setEdge(parentId, nodeId)
                 nodeIdsForThisComponent.add(nodeId)
             }

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -172,8 +172,8 @@ def computeHashes(File file) {
     return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
-// Reduce a resource URL to its canonical location — scheme://host[:port]/path —
-// by parsing it as a URI and dropping userInfo, query and fragment.
+// Reduce an already-parsed resource URI to its canonical location —
+// scheme://host[:port]/path — by dropping userInfo, query and fragment.
 // Standard Maven/Gradle repos authenticate via headers and serve artifacts at
 // plain path-based URLs, but a repo configured with credentials embedded in the
 // URL (https://user:pass@host/repo) carries that userInfo on every artifact
@@ -182,12 +182,22 @@ def computeHashes(File file) {
 // location (at most a request-scoped redirect artefact), so the bare path is
 // the correct, reproducible provenance value. Operating on the parsed URI keeps
 // the rule single and robust.
-def canonicalUrl(String url) {
+def canonicalUrl(URI u) {
     try {
-        def u = new URI(url)
-        return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
+        // Reduce to the authority minus any embedded userInfo. We can't use
+        // u.host/u.port here: Java leaves getHost() null for any authority it
+        // deems registry-based rather than server-based — notably hosts
+        // containing an underscore, common on internal Maven mirrors — which
+        // would silently drop the host from the label. getAuthority() preserves
+        // it, so we strip the "user:pass@" prefix ourselves to keep credentials
+        // out of the dep-graph/SBOM.
+        def authority = u.authority
+        if (authority == null) return null
+        int at = authority.lastIndexOf('@')
+        if (at >= 0) authority = authority.substring(at + 1)
+        return new URI(u.scheme, authority, u.path, null, null).toString()
     } catch (Exception ignored) {
-        // Fail closed: if the URL can't be parsed and rebuilt from its
+        // Fail closed: if the URI can't be rebuilt from its
         // components we cannot guarantee userinfo/query/fragment were stripped,
         // so drop it entirely rather than risk a credential surviving into a
         // label. The caller records nothing when this returns null.
@@ -240,7 +250,7 @@ def recordResourceRead(buildOp) {
         int slash = path.lastIndexOf('/')
         if (slash < 0 || slash == path.length() - 1) return
         def filename = path.substring(slash + 1)
-        def clean = canonicalUrl(url)
+        def clean = canonicalUrl(uri)
         if (clean == null) return
         snykUrlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -122,17 +122,30 @@ class Sha1Map {
     }
 }
 
-def hash(File file) {
-    def md = java.security.MessageDigest.getInstance('SHA-1')
-    file.eachByte(1024 * 4) { buffer, len ->
-        md.update(buffer, 0, len)
+// Stream a file once, feeding every requested digest from a single read.
+// `algorithms` maps the JDK algorithm name to its output label; returns
+// {label: lowercase-hex}. Shared by every file-hashing helper below.
+def digestFile(File file, Map<String, String> algorithms) {
+    def digests = algorithms.collectEntries { javaName, _label ->
+        [(javaName): java.security.MessageDigest.getInstance(javaName)]
     }
-    return md.digest().encodeHex().toString()
+    file.eachByte(1024 * 8) { buffer, len ->
+        digests.each { _name, md -> md.update(buffer, 0, len) }
+    }
+    return digests.collectEntries { javaName, md ->
+        [(algorithms[javaName]): md.digest().encodeHex().toString()]
+    }
 }
 
+// SHA-1 hex of a file's contents (normalized-mode node id).
+def hash(File file) {
+    return digestFile(file, ['SHA-1': 'sha-1'])['sha-1']
+}
+
+// SHA-1 hex of a string (fallback node id when a file hash is unavailable).
+// Hashes in-memory bytes one-shot, so it does not use digestFile.
 def hashString(String str) {
-    def md = java.security.MessageDigest.getInstance('SHA-1')
-    return md.digest(str.bytes).encodeHex().toString()
+    return java.security.MessageDigest.getInstance('SHA-1').digest(str.bytes).encodeHex().toString()
 }
 
 // ── Component metadata (opt-in: -PsnykIncludeComponentMetadata) ──────────────
@@ -156,14 +169,7 @@ def hashString(String str) {
 // Compute md5/sha-1/sha-256/sha-512 in a single pass over the file bytes.
 // Keys match the CycloneDX-friendly label suffixes used across ecosystems.
 def computeHashes(File file) {
-    def algos = ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512']
-    def digests = algos.collectEntries { javaName, _label -> [(javaName): java.security.MessageDigest.getInstance(javaName)] }
-    file.eachByte(1024 * 8) { buffer, len ->
-        digests.each { _name, md -> md.update(buffer, 0, len) }
-    }
-    def result = [:]
-    digests.each { javaName, md -> result[algos[javaName]] = md.digest().encodeHex().toString() }
-    return result
+    return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
 // Reduce a resource URL to its canonical, credential-free location —

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -172,13 +172,15 @@ def computeHashes(File file) {
     return digestFile(file, ['MD5': 'md5', 'SHA-1': 'sha-1', 'SHA-256': 'sha-256', 'SHA-512': 'sha-512'])
 }
 
-// Reduce a resource URL to its canonical, credential-free location —
-// scheme://host[:port]/path — by parsing it as a URI and dropping userInfo,
-// query and fragment. The query is where URL-borne auth lives (Azure Blob SAS
-// tokens, GCS/S3 signed-URL signatures); it is request-scoped and never part
-// of the artifact's durable location, so it is dropped wholesale rather than
-// by enumerating credential parameter names. Basic-auth userInfo is dropped
-// for the same reason. Operating on the parsed URI (not string surgery) keeps
+// Reduce a resource URL to its canonical location — scheme://host[:port]/path —
+// by parsing it as a URI and dropping userInfo, query and fragment.
+// Standard Maven/Gradle repos authenticate via headers and serve artifacts at
+// plain path-based URLs, but a repo configured with credentials embedded in the
+// URL (https://user:pass@host/repo) carries that userInfo on every artifact
+// URL, so we strip it to keep credentials out of the dep-graph/SBOM. Query and
+// fragment are dropped too: they are not part of the artifact's durable
+// location (at most a request-scoped redirect artefact), so the bare path is
+// the correct, reproducible provenance value. Operating on the parsed URI keeps
 // the rule single and robust.
 def canonicalUrl(String url) {
     try {

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -185,9 +185,11 @@ def canonicalUrl(String url) {
         def u = new URI(url)
         return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
     } catch (Exception ignored) {
-        // Unparseable — still make a best effort to drop query/fragment so a
-        // token in the query can never survive into a label.
-        return url.replaceAll(/[?#].*$/, '')
+        // Fail closed: if the URL can't be parsed and rebuilt from its
+        // components we cannot guarantee userinfo/query/fragment were stripped,
+        // so drop it entirely rather than risk a credential surviving into a
+        // label. The caller records nothing when this returns null.
+        return null
     }
 }
 
@@ -236,9 +238,11 @@ def recordResourceRead(buildOp) {
         int slash = path.lastIndexOf('/')
         if (slash < 0 || slash == path.length() - 1) return
         def filename = path.substring(slash + 1)
+        def clean = canonicalUrl(url)
+        if (clean == null) return
         snykUrlsByFilename
             .computeIfAbsent(filename) { _ -> java.util.Collections.synchronizedSet(new LinkedHashSet()) }
-            .add(canonicalUrl(url))
+            .add(clean)
     } catch (Exception ignored) { /* one bad op must not break resolution */ }
 }
 

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -65,18 +65,24 @@ class GradleGraph {
         this.rootId = rootId
     }
 
-    Map setNode(String key, Map value, Map metadata = null) {
+    Map setNode(String key, Map value, Closure metadataProvider = null) {
         if (!key || !value) {
             return null
         }
 
         nodes.computeIfAbsent(key) { _ ->
             def node = ['name': value.name, 'version': value.version, 'parentIds': [] as Set]
-            // Component metadata (opt-in via -PsnykIncludeComponentMetadata). Only
-            // the first emission of a nodeId wins — consistent with name/version.
-            if (metadata) {
-                if (metadata.hashes) node.hashes = metadata.hashes
-                if (metadata.distributionUrl) node.distributionUrl = metadata.distributionUrl
+            // Component metadata (opt-in via -PsnykIncludeComponentMetadata).
+            // Computed lazily and only when the nodeId is genuinely new: a
+            // shared component is re-walked once per incoming edge, but only the
+            // first emission wins, so hashing on every edge would be wasted disk
+            // I/O and CPU. Evaluating inside computeIfAbsent runs it exactly once.
+            if (metadataProvider) {
+                def metadata = metadataProvider()
+                if (metadata) {
+                    if (metadata.hashes) node.hashes = metadata.hashes
+                    if (metadata.distributionUrl) node.distributionUrl = metadata.distributionUrl
+                }
             }
             node
         }
@@ -220,8 +226,11 @@ def recordResourceRead(buildOp) {
 }
 
 // Read the requested -P property at init time; project properties surface on
-// the start parameter before any project is evaluated.
-snykIncludeComponentMetadata = gradle.startParameter.projectProperties.containsKey('snykIncludeComponentMetadata')
+// the start parameter before any project is evaluated. Gate on the property's
+// value (not mere presence) so an explicit =false disables the feature,
+// matching the snyk-deps-init.gradle resolver.
+snykIncludeComponentMetadata = gradle.startParameter.projectProperties
+    .get('snykIncludeComponentMetadata')?.toBoolean() ?: false
 if (snykIncludeComponentMetadata) {
     registerResourceReadListener()
 }
@@ -244,20 +253,21 @@ def buildArtifactMetadata(artifact, String name, String version) {
     }
 }
 
-// Resolve a filename to the URL it was actually read from. When a filename maps
-// to more than one captured URL (shared cache seeing multiple repos), pick the
-// one whose path matches this artifact's Maven layout; if still ambiguous,
-// emit nothing rather than guess.
+// Resolve a filename to the URL it was actually read from. Always confirm the
+// captured URL belongs to THIS artifact's Maven-layout path before labelling:
+// a shared build can read the same filename from more than one repo, and even
+// a lone captured URL may belong to a different GAV that happens to share a
+// filename. If no candidate — or more than one — matches the layout, emit
+// nothing rather than guess.
 def lookupDistributionUrl(String name, String version, String fileName) {
     def candidates = snykUrlsByFilename.get(fileName)
     if (!candidates || candidates.isEmpty()) return null
-    if (candidates.size() == 1) return candidates.iterator().next()
     try {
         def group = name.contains(':') ? name.substring(0, name.indexOf(':')) : name
         def module = name.contains(':') ? name.substring(name.indexOf(':') + 1) : name
         def suffix = "/${group.replace('.', '/')}/${module}/${version}/${fileName}".toString()
-        def match = candidates.find { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
-        if (match) return match
+        def matches = candidates.findAll { it.replaceAll(/[?#].*$/, '').endsWith(suffix) }
+        if (matches.size() == 1) return matches[0]
     } catch (Exception ignored) { /* fall through to no-label */ }
     return null
 }
@@ -397,7 +407,7 @@ def walkComponent(component, GradleGraph graph, String parentId,
                     nodeId = coordinate
                     coordToNodeId[coordinate] = nodeId
                 }
-                graph.setNode(nodeId, ['name': name, 'version': version], buildArtifactMetadata(a, name, version))
+                graph.setNode(nodeId, ['name': name, 'version': version]) { buildArtifactMetadata(a, name, version) }
                 graph.setEdge(parentId, nodeId)
                 nodeIdsForThisComponent.add(nodeId)
             }

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -236,6 +236,18 @@ def registerResourceReadListener() {
             finished: { buildOp, finishEvent -> recordResourceRead(buildOp) },
         ] as org.gradle.internal.operations.BuildOperationListener
         manager.addListener(listener)
+        // BuildOperationListenerManager is a daemon-scoped service, so a listener
+        // added here otherwise survives into later builds on a reused daemon —
+        // accumulating one per build, each pinning its build's captured state.
+        // Remove it when this build finishes. buildFinished is deprecated on newer
+        // Gradle but remains the most portable cleanup hook across 4.x–9.x;
+        // guarded so an unavailable hook never breaks resolution.
+        try {
+            gradle.buildFinished { manager.removeListener(listener) }
+        } catch (Exception ignored) {
+            // No usable build-finished hook: the listener is reclaimed when the
+            // daemon exits, so the worst case is a bounded per-build leak.
+        }
         debugLog('component-metadata: resource-read listener registered')
     } catch (Exception e) {
         debugLog("component-metadata: listener registration failed (${e.class.simpleName}: ${e.message}); distribution:url unavailable")

--- a/lib/init.gradle
+++ b/lib/init.gradle
@@ -197,18 +197,28 @@ def computeHashes(File file) {
 // the rule single and robust.
 def canonicalUrl(URI u) {
     try {
-        // Reduce to the authority minus any embedded userInfo. We can't use
-        // u.host/u.port here: Java leaves getHost() null for any authority it
-        // deems registry-based rather than server-based — notably hosts
-        // containing an underscore, common on internal Maven mirrors — which
-        // would silently drop the host from the label. getAuthority() preserves
-        // it, so we strip the "user:pass@" prefix ourselves to keep credentials
-        // out of the dep-graph/SBOM.
-        def authority = u.authority
-        if (authority == null) return null
-        int at = authority.lastIndexOf('@')
-        if (at >= 0) authority = authority.substring(at + 1)
-        return new URI(u.scheme, authority, u.path, null, null).toString()
+        // Server-based authority: host and port are parsed out, so rebuild from
+        // components with an explicit null userInfo.
+        if (u.host != null) {
+            return new URI(u.scheme, null, u.host, u.port, u.path, null, null).toString()
+        }
+        // Registry-based authority: java.net.URI implements RFC 2396, whose
+        // hostname grammar allows only alphanumerics and "-", so an authority it
+        // can't parse as host[:port] — one underscore is enough, common on
+        // internal Maven mirrors — falls back to an opaque registry name with
+        // host, port and userInfo all left null. The authority is then the only
+        // component that survives, so strip the "user:pass@" prefix by hand.
+        //
+        // Split the *raw* authority: it keeps percent-escapes intact, so the only
+        // unencoded "@" is the userInfo delimiter. On the decoded authority a
+        // host containing %40 would arrive as a second "@" and get mistaken for
+        // one. Split on the last "@" because an unencoded "@" in a password is
+        // malformed but survivable, and the last one is still the delimiter.
+        def raw = u.rawAuthority
+        if (raw == null) return null
+        int at = raw.lastIndexOf('@')
+        if (at >= 0) raw = raw.substring(at + 1)
+        return new URI(u.scheme + '://' + raw + (u.rawPath ?: '')).toString()
     } catch (Exception ignored) {
         // Fail closed: if the URI can't be rebuilt from its
         // components we cannot guarantee userinfo/query/fragment were stripped,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,9 +71,9 @@ export interface GradleInspectOptions {
   // https://developer.android.com/studio/build/dependencies#variant_aware )
   'configuration-attributes'?: string;
 
-  // For some reason, `--no-daemon` is not required for Unix, but on Windows, without this flag, apparently,
-  // Gradle process just never exits, from the Node's standpoint.
-  // Leaving default usage `--no-daemon`, because of backwards compatibility
+  // When false/undefined the plugin passes `--no-daemon` on every platform so
+  // each invocation is a fresh, one-shot JVM. Set true to reuse a daemon (faster
+  // for repeated builds, but the daemon accumulates heap across invocations).
   daemon?: boolean;
   initScript?: string;
   gradleNormalizeDeps?: boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -77,6 +77,18 @@ export interface GradleInspectOptions {
   daemon?: boolean;
   initScript?: string;
   gradleNormalizeDeps?: boolean;
+
+  // Emit component-metadata node labels (hash:<alg> and, when the real
+  // resolution was observed, distribution:url). Passed to init.gradle as
+  // -PsnykIncludeComponentMetadata. Off by default.
+  includeComponentMetadata?: boolean;
+
+  // Force `--refresh-dependencies` so metadata reads fire and distribution:url
+  // is populated even on a warm cache. Opt-in: forces network access and can
+  // re-resolve dynamic/SNAPSHOT versions. No-op under `--offline`. Only affects
+  // distribution:url coverage; hash:<alg> labels are unaffected. The same effect
+  // is available on the legacy path via `snyk test -- --refresh-dependencies`.
+  gradleRefreshDependencies?: boolean;
 }
 
 export interface CliOptions {

--- a/test/fixtures/component-metadata-credentialled-repo/build.gradle
+++ b/test/fixtures/component-metadata-credentialled-repo/build.gradle
@@ -6,9 +6,16 @@ apply plugin: 'java'
 // listener in init.gradle — which is what makes the credential stripping in
 // canonicalUrl observable from a test. The credentials are deliberate
 // throwaway placeholders, not redacted real ones.
+//
+// The password deliberately contains an "@" (percent-encoded as %40, as a valid
+// URL requires). URI.getAuthority() returns userInfo *decoded*, so this arrives
+// at canonicalUrl as "dummy-user:dummy-p@ss@repo1.maven.org" — two "@" in one
+// authority. That is what forces the split on the *last* "@": splitting on the
+// first would emit "ss@repo1.maven.org" and leak the password tail into the
+// label.
 repositories {
   maven {
-    url = 'https://dummy-user:dummy-pass@repo1.maven.org/maven2'
+    url = 'https://dummy-user:dummy-p%40ss@repo1.maven.org/maven2'
   }
 }
 

--- a/test/fixtures/component-metadata-credentialled-repo/build.gradle
+++ b/test/fixtures/component-metadata-credentialled-repo/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'java'
+
+// Maven Central, but reached through a repository URL carrying embedded
+// credentials. Central ignores auth it doesn't need, so resolution succeeds
+// while Gradle still reports the userInfo-bearing URL to the resource-read
+// listener in init.gradle — which is what makes the credential stripping in
+// canonicalUrl observable from a test. The credentials are deliberate
+// throwaway placeholders, not redacted real ones.
+repositories {
+  maven {
+    url = 'https://dummy-user:dummy-pass@repo1.maven.org/maven2'
+  }
+}
+
+dependencies {
+  implementation 'batik:batik-dom:1.6'
+}

--- a/test/functional/graph.spec.ts
+++ b/test/functional/graph.spec.ts
@@ -253,6 +253,71 @@ describe('buildGraph', () => {
     expected.connectDep('com.private:a@1', 'com.public:b@1');
     expect(received.equals(expected.build())).toBe(true);
   });
+  it('labels nodes with component metadata (hash:* and distribution:url)', async () => {
+    const received = await buildGraph(
+      {
+        'com.google.guava:guava:jar@30.1.1-jre': {
+          name: 'com.google.guava:guava',
+          version: '30.1.1-jre',
+          parentIds: ['root-node'],
+          hashes: {
+            'sha-1': '87e0fd1df874ea3cbe577702fe6f17068b790fd8',
+            'sha-256':
+              '44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06',
+          },
+          distributionUrl:
+            'https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1.1-jre/guava-30.1.1-jre.jar',
+        },
+      },
+      'project',
+      '1.2.3',
+    );
+    const nodes = received.getPkgNodes({
+      name: 'com.google.guava:guava',
+      version: '30.1.1-jre',
+    });
+    expect(nodes).toContainEqual({
+      info: {
+        labels: {
+          'hash:sha-1': '87e0fd1df874ea3cbe577702fe6f17068b790fd8',
+          'hash:sha-256':
+            '44ce229ce26d880bf3afc362bbfcec34d7e6903d195bbb1db9f3b6e0d9834f06',
+          'distribution:url':
+            'https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1.1-jre/guava-30.1.1-jre.jar',
+        },
+      },
+    });
+  });
+
+  it('emits hash labels without distribution:url when the URL is absent (warm cache)', async () => {
+    const received = await buildGraph(
+      {
+        'a:b:jar@1': {
+          name: 'a:b',
+          version: '1',
+          parentIds: ['root-node'],
+          hashes: { 'sha-1': 'deadbeef' },
+        },
+      },
+      'project',
+      '1.2.3',
+    );
+    const nodes = received.getPkgNodes({ name: 'a:b', version: '1' });
+    expect(nodes).toContainEqual({
+      info: { labels: { 'hash:sha-1': 'deadbeef' } },
+    });
+  });
+
+  it('adds no component-metadata labels when the node carries none', async () => {
+    const received = await buildGraph(
+      { 'a:b:jar@1': { name: 'a:b', version: '1', parentIds: ['root-node'] } },
+      'project',
+      '1.2.3',
+    );
+    const nodes = received.getPkgNodes({ name: 'a:b', version: '1' });
+    expect(nodes).toContainEqual({ info: {} });
+  });
+
   it('labels nodes with pkgIdProvenance when the co-ordinate is changed', async () => {
     const received = await buildGraph(
       {

--- a/test/system/component-metadata.test.ts
+++ b/test/system/component-metadata.test.ts
@@ -1,0 +1,105 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DepGraph } from '@snyk/dep-graph';
+import { fixtureDir } from '../common';
+import { inspect } from '../../lib';
+
+const noWrapper = fixtureDir('no wrapper');
+const buildGradle = path.join(noWrapper, 'build.gradle');
+
+// Expected lowercase-hex length of each digest label the init script emits.
+const hashLabelLengths: Record<string, number> = {
+  'hash:md5': 32, // 16 bytes
+  'hash:sha-1': 40, // 20 bytes
+  'hash:sha-256': 64, // 32 bytes
+  'hash:sha-512': 128, // 64 bytes
+};
+
+type LabelledNode = {
+  nodeId: string;
+  info?: { labels?: Record<string, string> };
+};
+
+function nodesWithLabels(depGraph: DepGraph): LabelledNode[] {
+  const json = depGraph.toJSON();
+  return (json.graph.nodes as LabelledNode[]).filter(
+    (n) => n.info && n.info.labels,
+  );
+}
+
+describe('includeComponentMetadata', () => {
+  test('emits hash:<alg> and a credential-free distribution:url', async () => {
+    // A fresh Gradle user home forces the artifacts to be downloaded during
+    // this run so the resource-read listener fires and distribution:url is
+    // populated. The gradle subprocess inherits process.env (see sub-process.ts).
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gradle-home-'));
+    const prevHome = process.env.GRADLE_USER_HOME;
+    process.env.GRADLE_USER_HOME = tmpHome;
+
+    try {
+      const result = await inspect('.', buildGradle, {
+        includeComponentMetadata: true,
+        gradleRefreshDependencies: true,
+      });
+
+      const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
+      const withHashes = nodes.filter((n) => n.info!.labels!['hash:sha-256']);
+      expect(withHashes.length).toBeGreaterThan(0);
+
+      let sawDistributionUrl = false;
+      for (const node of withHashes) {
+        const labels = node.info!.labels!;
+        for (const [label, len] of Object.entries(hashLabelLengths)) {
+          const value = labels[label];
+          expect(value).toBeDefined();
+          expect(value).toHaveLength(len);
+          expect(value).toMatch(/^[0-9a-f]+$/);
+        }
+
+        const distUrl = labels['distribution:url'];
+        if (distUrl) {
+          sawDistributionUrl = true;
+          // The credential-safety contract: canonical location only — no
+          // query string or fragment (where SAS tokens / signed-URL signatures
+          // live) and no basic-auth userinfo.
+          expect(distUrl).toMatch(/^https?:\/\//);
+          expect(distUrl).not.toContain('?');
+          expect(distUrl).not.toContain('#');
+          const parsed = new URL(distUrl);
+          expect(parsed.username).toBe('');
+          expect(parsed.password).toBe('');
+          expect(parsed.search).toBe('');
+        }
+      }
+
+      if (!sawDistributionUrl) {
+        // Best-effort: distribution:url depends on the internal build-operation
+        // listener being available on this Gradle version. Hashes are still
+        // asserted above; surface the gap rather than failing silently.
+        console.warn(
+          'no distribution:url labels were captured; hash coverage was still asserted',
+        );
+      }
+    } finally {
+      if (prevHome === undefined) {
+        delete process.env.GRADLE_USER_HOME;
+      } else {
+        process.env.GRADLE_USER_HOME = prevHome;
+      }
+    }
+  });
+
+  test('emits no component-metadata labels when the flag is off', async () => {
+    const result = await inspect('.', buildGradle);
+
+    const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
+    for (const node of nodes) {
+      const labels = Object.keys(node.info!.labels!);
+      const metadataLabels = labels.filter(
+        (l) => l.startsWith('hash:') || l === 'distribution:url',
+      );
+      expect(metadataLabels).toEqual([]);
+    }
+  });
+});

--- a/test/system/component-metadata.test.ts
+++ b/test/system/component-metadata.test.ts
@@ -6,6 +6,17 @@ import { inspect } from '../../lib';
 const noWrapper = fixtureDir('no wrapper');
 const buildGradle = path.join(noWrapper, 'build.gradle');
 
+// A fixture whose repository URL embeds credentials; see its build.gradle.
+const credentialledRepo = fixtureDir('component-metadata-credentialled-repo');
+const credentialledRepoBuildGradle = path.join(
+  credentialledRepo,
+  'build.gradle',
+);
+
+// The throwaway credentials embedded in that fixture's repository URL.
+const dummyUser = 'dummy-user';
+const dummyPass = 'dummy-pass';
+
 // Expected lowercase-hex length of each digest label the init script emits.
 const hashLabelLengths: Record<string, number> = {
   'hash:md5': 32, // 16 bytes
@@ -16,6 +27,7 @@ const hashLabelLengths: Record<string, number> = {
 
 type LabelledNode = {
   nodeId: string;
+  pkgId: string;
   info?: { labels?: Record<string, string> };
 };
 
@@ -47,12 +59,42 @@ describe('includeComponentMetadata', () => {
     }
   });
 
-  // NOTE: distribution:url is intentionally not asserted here. This fixture
-  // resolves from Maven Central, whose URLs carry no credentials/query, so it
-  // cannot exercise the credential-stripping (canonicalUrl) logic — a passing
-  // assertion would give false certainty. Meaningfully testing distribution:url
-  // (and the stripping) needs a controlled local HTTP repo serving artifacts
-  // via query-string URLs; tracked as a follow-up.
+  // Covers the whole distribution:url path end to end: the resource-read
+  // listener capturing a real URL, the Maven-layout match in
+  // lookupDistributionUrl, and canonicalUrl dropping the userInfo.
+  //
+  // Not covered: canonicalUrl also strips query and fragment, which no Gradle
+  // build can actually produce. Gradle normalises both off a repository URL
+  // before resolution, so the listener never observes them — verified
+  // empirically, not assumed. That branch is fail-safe defence against a future
+  // Gradle exposing a richer location, so it stays, but it is unreachable from
+  // here and a local HTTP repo would not change that.
+  test('strips embedded credentials from distribution:url', async () => {
+    const result = await inspect('.', credentialledRepoBuildGradle, {
+      includeComponentMetadata: true,
+      // distribution:url is only emitted for reads we actually observe, and a
+      // warm Gradle cache re-fetches nothing. Force re-validation so the read
+      // happens regardless of cache state — without this the label is
+      // legitimately absent on any run after the first.
+      gradleRefreshDependencies: true,
+    });
+
+    const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
+    // Match on pkgId: nodeId additionally carries the artifact type
+    // (batik:batik-dom:jar@1.6).
+    const batik = nodes.find((n) => n.pkgId === 'batik:batik-dom@1.6');
+    expect(batik).toBeDefined();
+
+    const url = batik!.info!.labels!['distribution:url'];
+    expect(url).toBe(
+      'https://repo1.maven.org/maven2/batik/batik-dom/1.6/batik-dom-1.6.jar',
+    );
+    // Implied by the exact match above, but asserted directly so that changing
+    // the expected URL can never quietly reintroduce a credential leak.
+    expect(url).not.toContain(dummyUser);
+    expect(url).not.toContain(dummyPass);
+    expect(url).not.toContain('@');
+  });
 
   test('emits no component-metadata labels when the flag is off', async () => {
     const result = await inspect('.', buildGradle);

--- a/test/system/component-metadata.test.ts
+++ b/test/system/component-metadata.test.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { DepGraph } from '@snyk/dep-graph';
 import { fixtureDir } from '../common';
@@ -29,74 +27,39 @@ function nodesWithLabels(depGraph: DepGraph): LabelledNode[] {
 }
 
 describe('includeComponentMetadata', () => {
-  test('emits hash:<alg> and a credential-free distribution:url', async () => {
-    // A fresh Gradle user home forces the artifacts to be downloaded during
-    // this run so the resource-read listener fires and distribution:url is
-    // populated. The gradle subprocess inherits process.env (see sub-process.ts).
-    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gradle-home-'));
-    const prevHome = process.env.GRADLE_USER_HOME;
-    process.env.GRADLE_USER_HOME = tmpHome;
+  test('emits hash:<alg> labels for resolved artifacts', async () => {
+    const result = await inspect('.', buildGradle, {
+      includeComponentMetadata: true,
+    });
 
-    try {
-      const result = await inspect('.', buildGradle, {
-        includeComponentMetadata: true,
-        gradleRefreshDependencies: true,
-      });
+    const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
+    const withHashes = nodes.filter((n) => n.info!.labels!['hash:sha-256']);
+    expect(withHashes.length).toBeGreaterThan(0);
 
-      const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
-      const withHashes = nodes.filter((n) => n.info!.labels!['hash:sha-256']);
-      expect(withHashes.length).toBeGreaterThan(0);
-
-      let sawDistributionUrl = false;
-      for (const node of withHashes) {
-        const labels = node.info!.labels!;
-        for (const [label, len] of Object.entries(hashLabelLengths)) {
-          const value = labels[label];
-          expect(value).toBeDefined();
-          expect(value).toHaveLength(len);
-          expect(value).toMatch(/^[0-9a-f]+$/);
-        }
-
-        const distUrl = labels['distribution:url'];
-        if (distUrl) {
-          sawDistributionUrl = true;
-          // The credential-safety contract: canonical location only — no
-          // query string or fragment (where SAS tokens / signed-URL signatures
-          // live) and no basic-auth userinfo.
-          expect(distUrl).toMatch(/^https?:\/\//);
-          expect(distUrl).not.toContain('?');
-          expect(distUrl).not.toContain('#');
-          const parsed = new URL(distUrl);
-          expect(parsed.username).toBe('');
-          expect(parsed.password).toBe('');
-          expect(parsed.search).toBe('');
-        }
-      }
-
-      if (!sawDistributionUrl) {
-        // Best-effort: distribution:url depends on the internal build-operation
-        // listener being available on this Gradle version. Hashes are still
-        // asserted above; surface the gap rather than failing silently.
-        console.warn(
-          'no distribution:url labels were captured; hash coverage was still asserted',
-        );
-      }
-    } finally {
-      if (prevHome === undefined) {
-        delete process.env.GRADLE_USER_HOME;
-      } else {
-        process.env.GRADLE_USER_HOME = prevHome;
+    for (const node of withHashes) {
+      const labels = node.info!.labels!;
+      for (const [label, len] of Object.entries(hashLabelLengths)) {
+        const value = labels[label];
+        expect(value).toBeDefined();
+        expect(value).toHaveLength(len);
+        expect(value).toMatch(/^[0-9a-f]+$/);
       }
     }
   });
+
+  // NOTE: distribution:url is intentionally not asserted here. This fixture
+  // resolves from Maven Central, whose URLs carry no credentials/query, so it
+  // cannot exercise the credential-stripping (canonicalUrl) logic — a passing
+  // assertion would give false certainty. Meaningfully testing distribution:url
+  // (and the stripping) needs a controlled local HTTP repo serving artifacts
+  // via query-string URLs; tracked as a follow-up.
 
   test('emits no component-metadata labels when the flag is off', async () => {
     const result = await inspect('.', buildGradle);
 
     const nodes = nodesWithLabels(result.dependencyGraph as DepGraph);
     for (const node of nodes) {
-      const labels = Object.keys(node.info!.labels!);
-      const metadataLabels = labels.filter(
+      const metadataLabels = Object.keys(node.info!.labels!).filter(
         (l) => l.startsWith('hash:') || l === 'distribution:url',
       );
       expect(metadataLabels).toEqual([]);

--- a/test/system/component-metadata.test.ts
+++ b/test/system/component-metadata.test.ts
@@ -13,9 +13,10 @@ const credentialledRepoBuildGradle = path.join(
   'build.gradle',
 );
 
-// The throwaway credentials embedded in that fixture's repository URL.
+// The throwaway credentials embedded in that fixture's repository URL. The
+// password contains an "@" on purpose — see the fixture's build.gradle.
 const dummyUser = 'dummy-user';
-const dummyPass = 'dummy-pass';
+const dummyPass = 'dummy-p@ss';
 
 // Expected lowercase-hex length of each digest label the init script emits.
 const hashLabelLengths: Record<string, number> = {


### PR DESCRIPTION
## What

Adds opt-in **component-metadata** node labels to the Gradle resolver, using the
same cross-ecosystem vocabulary as `snyk-mvn-plugin` and `nodejs-lockfile-parser`:

- `hash:<alg>` — lowercase-hex `md5` / `sha-1` / `sha-256` / `sha-512` digests of
  the resolved artifact file.
- `distribution:url` — the real remote URL Gradle read the artifact from.

Enabled via the `includeComponentMetadata` inspect option (passed to the init
script as `-PsnykIncludeComponentMetadata=true`). Off by default; no behaviour
change unless requested.

`distribution:url` is **true provenance only** — Gradle's public API exposes no
per-artifact source repository, so the real resource-read URLs are captured via
an internal build-operation listener. That path is best-effort: if the internal
API is unavailable on a given Gradle version, or nothing is re-fetched on a warm
cache, the node simply carries no `distribution:url` (never a reconstructed
guess). `gradleRefreshDependencies` forces `--refresh-dependencies` so the reads
fire and `distribution:url` is populated even on a warm cache.

## On `distribution:url` sanitising

The value is reduced at capture to `scheme://host[:port]/path`. The realistic
in-URL credential vector is **userInfo** — a repo configured as
`https://user:pass@host/repo` carries it on every artifact URL — which this
strips so it can't reach the dep-graph/SBOM. Query and fragment are dropped as
**canonicalisation**: they are not part of the artifact's durable location (at
most a request-scoped redirect artefact), so the bare path is the correct,
reproducible provenance value. It is not a defence against exotic signed-URL
token schemes (Azure SAS / S3-presigned) — those don't arise for normal
header-authenticated, path-based Maven/Gradle repos. `canonicalUrl` fails closed:
an un-sanitisable URL is dropped rather than risking a leak.

## Testing

- `test/system/component-metadata.test.ts`: flag on → every resolved external
  node carries all four hashes as lowercase hex; flag off → no such labels.
  Passing locally on Gradle 9.4.1 / JDK 21.

### Example `snyk sbom` output with built cli
```
  "components": [
    {
      "bom-ref": "2-org.jetbrains.kotlin:kotlin-stdlib-jdk8@2.2.0",
      "type": "library",
      "group": "org.jetbrains.kotlin",
      "name": "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
      "version": "2.2.0",
      "hashes": [
        {
          "alg": "MD5",
          "content": "5fe4006cd33776d7709096d3f9fa97ca"
        },
        {
          "alg": "SHA-1",
          "content": "ed572b04cd66acce7837ad753e4fe64d9c536025"
        },
        {
          "alg": "SHA-256",
          "content": "adc16648dbbcf35b0d10e7ec301c35d746d1c2fe460c606aba59f12b117cf9b0"
        },
        {
          "alg": "SHA-512",
          "content": "6307f0854f21811b0b5ff54ada950d44391a813fa41bf3c0de74ebee4d5ca6b861eaa1bec9e6aa991c7942ea0b67a6504adb8198dd5a42d86240d58465e29dfb"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8@2.2.0",
      "externalReferences": [
        {
          "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.2.0/kotlin-stdlib-jdk8-2.2.0.jar",
          "type": "distribution"
        }
      ]
    },```

## Notes

- The init-script (Groovy) logic is only exercised by the system suite
  (`npm run test:system`), not the fast lint/functional lane.
- Companion change in `cli-extension-dep-graph` wires the same feature through
  the native resolver; the `digestFile` and `canonicalUrl` helpers are identical
  across both.

Draft: opening for review of the approach before finalising.
