### PR TITLE
fix: unblock CI (delisted SDKMAN JDKs) and upgrade shescape to 2.1.14 [security]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,14 @@ test_matrix_unix: &test_matrix_unix
   matrix:
     parameters:
       node_version: [ '20.20', '22.22', '24.16' ]
-      jdk_version: [ '8.0.292.j9-adpt' ]
+      jdk_version: [ '8.0.502-tem' ]
       gradle_version: [ '4.10', '5.5', '6.2.1']
 
 test_matrix_unix_new_versions: &test_matrix_unix_new_versions
   matrix:
     parameters:
       node_version: [ '20.20', '22.22', '24.16' ]
-      jdk_version: [ '17.0.9-jbr' ]
+      jdk_version: [ '17.0.14-jbr' ]
       gradle_version: [ '7.3', '8.4', '9.0.0', '9.2.0' ]
 
 test_matrix_win: &test_matrix_win

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "chalk": "^4.1.2",
     "p-map": "^4.0.0",
     "packageurl-js": "^1.2.1",
-    "shescape": "2.1.11",
+    "shescape": "2.1.14",
     "tmp": "^0.2.7",
     "tslib": "^2.8.1"
   },


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written (n/a)
- [x] Commit history is tidy

This PR does two things so it can be used to unblock the pipeline and clear the outstanding critical advisory in one merge.

### 1. Unblock CI — bump delisted SDKMAN JDK builds

The two SDKMAN-installed JDK builds pinned in the unix CI matrix have been removed from SDKMAN's catalogue, so every unix lane now fails at `sdk install java …` before any test runs:

```
Stop! java 8.0.292.j9-adpt is not available.
```

Bumped both pins to versions currently available on SDKMAN:

| lane | old (removed) | new |
| --- | --- | --- |
| `test_matrix_unix` | `8.0.292.j9-adpt` (AdoptOpenJDK OpenJ9, EOL) | `8.0.502-tem` |
| `test_matrix_unix_new_versions` | `17.0.9-jbr` | `17.0.14-jbr` |

No OpenJ9 JDK 8 build remains on SDKMAN, so the 8.x lane moves to Temurin (HotSpot); the 17.x lane keeps the JetBrains Runtime flavour. HotSpot vs OpenJ9 does not affect these tests. The install script's `JDK_MAJOR` detection still resolves `8` from `8.0.502-tem`, so the JDK-8 toolchain-provisioning branch is unaffected. Windows (`choco`) lanes are untouched.

### 2. Security — upgrade shescape to 2.1.14

Upgrades the direct `shescape` dependency `2.1.11 → 2.1.14` to remediate the **CRITICAL** Improper Neutralization advisory (`SNYK-JS-SHESCAPE-18319518`). This is the same bump as the bot-raised #346, folded in here so a single merge both unblocks CI and clears the advisory — #346 can be closed once this lands. Functional tests (including `test/functional/sub-process.spec.ts`, which covers the escaping paths in `lib/sub-process.ts`) pass on 2.1.14, and `npm install` reports 0 vulnerabilities.

### Notes for the reviewer

The CI change is pre-existing infra breakage unrelated to any code change — it blocks all PRs and `main`. The shescape bump is a patch-level upgrade with green functional tests.

#### How should this be manually tested?

CI installs a JDK on the unix lanes (the previously-failing step) and runs the suite on the upgraded `shescape`.
