### PR TITLE
Better error messaging until Gradle IP support is implemented

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,6 +40,14 @@ const cannotResolveVariantMarkers = [
   'Unable to find a matching variant of project',
 ];
 
+// Gradle's own wording when --no-configuration-cache (which this plugin passes on Gradle 7+)
+// meets a build with Isolated Projects enabled. Isolated Projects is built on the configuration
+// cache and cannot run without one, so the two are mutually exclusive and the build fails before
+// any dependency resolution happens.
+const isolatedProjectsMarkers = [
+  'Configuration Cache cannot be disabled when Isolated Projects is enabled',
+];
+
 type Options = api.InspectOptions & GradleInspectOptions & CliOptions;
 type VersionBuildInfo = api.VersionBuildInfo;
 
@@ -559,6 +567,35 @@ to
     ${chalk.whiteBright(
       "implementation project(path: ':mymodule', configuration: 'default')",
     )}`;
+    }
+
+    // Checked after the variant case: when Isolated Projects is what failed, nothing else in the
+    // build got far enough to be the real cause, so this message should win.
+    if (isolatedProjectsMarkers.find((m) => error.message.includes(m))) {
+      mainErrorMessage = `Error running Gradle dependency analysis.
+
+Your build has Gradle Isolated Projects enabled, which this plugin does not support yet.
+
+Isolated Projects is built on the configuration cache and cannot run without one, while this
+plugin passes ${chalk.whiteBright(
+        '--no-configuration-cache',
+      )} on Gradle 7 and above. Gradle rejects that
+combination before any dependency resolution happens, so the scan cannot start.
+
+Progress is tracked in ${chalk.whiteBright(
+        'https://github.com/snyk/snyk-gradle-plugin/issues/344',
+      )}.
+
+To scan in the meantime, turn Isolated Projects off for the scan. It is a Gradle property, so it
+can be overridden per invocation without editing your build:
+    ${chalk.whiteBright(
+      'snyk test -- -Dorg.gradle.unsafe.isolated-projects=false',
+    )}
+
+Use ${chalk.whiteBright(
+        '-Dorg.gradle.isolated-projects=false',
+      )} instead if your Gradle version has dropped the
+"unsafe" prefix from the property name.`;
     }
 
     error.message = `${chalk.red.bold(


### PR DESCRIPTION
### What this does

On Gradle 7+ this plugin passes `--no-configuration-cache`. Isolated Projects is built on the configuration cache and cannot run without one, so Gradle rejects the combination outright and the scan dies before any dependency resolution happens:

```
* What went wrong:
Configuration Cache cannot be disabled when Isolated Projects is enabled.
```

Nothing in that message mentions Snyk, and the flag it names is one the user never passed. It reads as a Gradle problem with their own build, so the natural next step is hunting through `gradle.properties` rather than looking for a Snyk limitation. This adds a message that names the cause, links the tracking issue, and gives a working per-invocation override.

Related issue: https://github.com/snyk/snyk-gradle-plugin/issues/344

Clarity only — this does not add Isolated Projects support.

#### How should this be manually tested?

Verified on Gradle 9.5.1 against `test/fixtures/multi-project`, adding one line to that fixture's `gradle.properties`:

```
org.gradle.unsafe.isolated-projects=true
```

Reproduce the failure the marker matches (this is the plugin's own invocation shape):

```
gradle snykResolvedDepsJson --project-dir test/fixtures/multi-project \
  -I "$(pwd)/lib/init.gradle" -PonlySubProject=. \
  --no-configuration-cache --no-daemon
```

Then confirm the override the message suggests does let a scan complete, with the property still `true`:

```
gradle snykResolvedDepsJson --project-dir test/fixtures/multi-project \
  -I "$(pwd)/lib/init.gradle" -PonlySubProject=. \
  -Dorg.gradle.unsafe.isolated-projects=false \
  --no-configuration-cache --no-daemon
```

That emits `JSONDEPS {...}` and `BUILD SUCCESSFUL`, so the advice is tested rather than assumed. Revert the fixture edit afterwards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error messaging and a guarded regex branch only; no change to Gradle invocation or dependency resolution behavior.
> 
> **Overview**
> When Gradle fails because **Isolated Projects** conflicts with the plugin’s **`--no-configuration-cache`** flag (Gradle 7+), users now get a dedicated error instead of the generic “check your arguments” message.
> 
> The change adds a **case-insensitive regex** on the stable core of Gradle’s wording (covers both pre- and post-9.5 phrasing), wires it as an **`else if`** after the Android variant-resolution branch so precedence stays explicit, and surfaces guidance: unsupported limitation, link to issue **#344**, and per-scan overrides via **`snyk test -- -Dorg.gradle.unsafe.isolated-projects=false`** (or the non-`unsafe` property on newer Gradle). The pattern is exported for tests; functional specs assert match against real Gradle messages and no false positives on other configuration-cache errors.
> 
> **No Isolated Projects support** is added—only clearer diagnostics and workaround instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45cc3765a04385ff6f56f200d1b6b9577542357c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->