### PR TITLE
chore: retag team ownership to sca-scanners [CMPA-724]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
           name: Security Scans
           node_version: "24.16"
           context:
-            - open_source-managed
+            - engines_sca-scanners
             - nodejs-install
             - prodsec-orb-runtime
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,8 @@ metadata:
   name: snyk-gradle-plugin
   annotations:
     github.com/project-slug: snyk/snyk-gradle-plugin
-    github.com/team-slug: snyk/os-managed
+    github.com/team-slug: snyk/engines_sca-scanners
 spec:
   type: snyk-cli-plugin
   lifecycle: "-"
-  owner: os-managed
+  owner: sca-scanners


### PR DESCRIPTION
### What?

`catalog-info.yaml` ownership metadata moves to the merged team:

| Field | Before | After |
|---|---|---|
| `owner` | retired team name | `sca-scanners` |
| `github.com/team-slug` | `snyk/<retired>` | `snyk/engines_sca-scanners` |

The two conventions differ on purpose: only **GitHub and CircleCI** carry the `engines_` group
prefix, so Backstage `owner` is the bare slug. Matches siblings such as `sca-findings`
(`owner: os-flows`) and `error-catalog` (`owner: cloud-experience`).

### CircleCI context

Also moves the CircleCI context from the `open_source-managed` stop-gap to the new
**`engines_sca-scanners`** context (`6070a8d4-dd66-4341-ae23-49571225b6da`), created by @wayne-grant
today — see the [#ask-prodsec thread](https://snyk.enterprise.slack.com/archives/C0BHRS7BW4A/p1787912064031849).
Per that discussion the plan is to go straight to the correct team rather than leave the stop-gap in place,
since these repos are being touched anyway.

Note contexts **do** carry the `engines_` prefix, unlike the Polaris/Backstage owner values above.

**Why this is safe here:** `engines_sca-scanners` currently provides only `SNYK_TOKEN`, whereas
`open_source-managed` also holds a `CIRCLECI_TOKEN`. Every job in this repo that requests the
context is a Snyk scanning job needing `SNYK_TOKEN` only — this repo references no Circle PAT at
all, so nothing loses a variable.


### Ownership is set in more places than expected

Rather than naming individual files, the transform walks **all of `helm/`** plus
`catalog-info.yaml`, matching on *key name + retired value* (never on parent path, which varies
per repo):

| Location | Keys |
|---|---|
| `catalog-info.yaml` | `owner`, `github.com/team-slug` |
| `helm/Chart.yaml` | `team` |
| `helm/values.yaml` | `owner`, `snykowner` — under `polaris-datadog-alerting` (the monitor tag), `polaris-namespace`, `namespace`, `global`, `polarisPostgres`, `polarisRedis*`, bucket blocks |
| `helm/values/<env>.yaml` | per-environment overrides |
| `helm/templates/**` incl. `_helpers.tpl` and subcharts | `snykowner`, `snyk.io/owner` — these become **labels and annotations on the running pods** |

Unrelated `owner:` keys are left alone — matching on the retired value means e.g. a secret owner
under `npmDepsAuthnToken.consumer` is untouched.

### Pruning stale `catalog-info.yaml` entries

Removed rather than updated, since each is either superseded or points somewhere that no longer
resolves:

| Entry | Why removed |
|---|---|
| `snyk.io/jira-prefix` | Names a Jira *project*, which is not renamed when a GitHub team is. It was being updated on the wrong trigger, and it is not the annotation the Backstage Jira plugin reads (`jira/project-key`). |
| Ask-channel link | Superseded by the `## Contact` section added to the README earlier in this migration. |
| Notion links | Notion is no longer used. |
| Datadog links naming a retired team | e.g. an SLO query `team:unify AND service:…` — stops resolving once the team tag changes, so the link would silently go stale. |
| `pagerduty.com/service-id` | Unused. |

Where pruning empties the `links:` block, the key itself is removed rather than left with no
entries. Datadog links that do **not** reference a retired team are left alone.

Every one of these is checked per repo and reported, so a repo that simply does not set them is
distinguishable from one that was skipped.

### Why?

`open-source_unify`, `open-source_analysis-platform`, `os-managed` and `os-ecosystems` have
merged into `@snyk/engines_sca-scanners` (CODEOWNERS already migrated under CMPA-724).

### Risk

**None to alerting.** This repo has no Polaris or Datadog configuration, so nothing about monitor
tagging or paging changes. Safe to merge at any time.

Not touched: Slack channels/handles/mentions, the `UNIFY` Jira prefix, dashboard/SLO URLs, and
`name:` / `project-slug:` fields — some repo names legitimately contain a retired team name.

---

> [!NOTE]
> **Low Risk**
> Metadata and CI context only; no code or runtime change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and CI secret context only; no product code, Helm, or alerting changes in this diff.
> 
> **Overview**
> **Retags** `snyk-gradle-plugin` to the merged **sca-scanners** team after the `os-managed` / open-source team consolidation.
> 
> **Backstage** (`catalog-info.yaml`): `spec.owner` becomes `sca-scanners` and `github.com/team-slug` becomes `snyk/engines_sca-scanners` (GitHub uses the `engines_` prefix; Backstage owner stays the bare slug).
> 
> **CircleCI**: the **Security Scans** workflow job drops the `open_source-managed` context in favor of **`engines_sca-scanners`**, which supplies `SNYK_TOKEN` for prodsec Snyk scanning—no application code or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435b7b8bff442848b568aea39a1dfcce977cf9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->